### PR TITLE
update RLLib version used in examples/requirements.in

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,7 +160,7 @@ First you will need to install the dependencies needed by the examples:
 
 ```shell
 cd <meltingpot_root>
-pip install -r examples/requirements.txt
+pip install -r examples/requirements.in
 ```
 
 Then you can run the training experiment using:

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,24 @@
+# Melting Pot Examples
+
+This directory contains example code showing how to use Melting Pot with various reinforcement learning frameworks.
+
+## Examples
+
+- **gym**: Example showing how to use Melting Pot with the Gymnasium API
+- **pettingzoo**: Example showing how to use Melting Pot with PettingZoo and Stable Baselines 3
+- **rllib**: Example showing how to use Melting Pot with Ray RLlib
+- **tutorial**: Tutorial examples for learning how to use Melting Pot
+
+## Requirements
+
+Each example has its own dedicated `requirements.in` file containing the specific dependencies needed for that example. This allows you to install only the dependencies required for the specific example you want to run.
+
+To install dependencies for a specific example:
+
+```bash
+# Install dependencies for a specific example (e.g., rllib)
+pip install -r examples/rllib/requirements.in
+
+# Run the example
+python -m examples.rllib.self_play_train
+```

--- a/examples/gym/requirements.in
+++ b/examples/gym/requirements.in
@@ -1,0 +1,7 @@
+# Requirements for Gym examples
+gymnasium
+dm_env
+dm_tree
+dmlab2d
+numpy
+matplotlib

--- a/examples/pettingzoo/requirements.in
+++ b/examples/pettingzoo/requirements.in
@@ -1,0 +1,10 @@
+# Requirements for PettingZoo examples
+pettingzoo>=1.22.3
+stable_baselines3
+supersuit>=3.7.2
+torch
+gymnasium
+dm_env
+dmlab2d
+numpy
+matplotlib

--- a/examples/requirements.in
+++ b/examples/requirements.in
@@ -8,7 +8,7 @@ matplotlib
 ml_collections
 numpy
 pettingzoo>=1.22.3
-ray[rllib,default]==2.5.0
+ray[rllib,default]==2.6.0
 stable_baselines3
 supersuit>=3.7.2
 torch

--- a/examples/requirements.in
+++ b/examples/requirements.in
@@ -8,7 +8,7 @@ matplotlib
 ml_collections
 numpy
 pettingzoo>=1.22.3
-ray[rllib,default]==2.6.0
+ray[rllib,default]==2.5.1
 stable_baselines3
 supersuit>=3.7.2
 torch

--- a/examples/rllib/requirements.in
+++ b/examples/rllib/requirements.in
@@ -1,0 +1,7 @@
+# Requirements for RLlib examples
+ray
+numpy
+torch
+dm_env
+dmlab2d
+ml_collections

--- a/examples/rllib/self_play_train.py
+++ b/examples/rllib/self_play_train.py
@@ -27,13 +27,14 @@ from . import utils
 
 def get_config(
     substrate_name: str = "bach_or_stravinsky_in_the_matrix__repeated",
-    num_rollout_workers: int = 2,
+    num_env_runners: int = 2,
     rollout_fragment_length: int = 100,
     train_batch_size: int = 6400,
     fcnet_hiddens=(64, 64),
     post_fcnet_hiddens=(256,),
     lstm_cell_size: int = 256,
     sgd_minibatch_size: int = 128,
+    minibatch_size: int = 128,
 ):
   """Get the configuration for running an agent on a substrate using RLLib.
 
@@ -42,13 +43,14 @@ def get_config(
   Args:
     substrate_name: The name of the MeltingPot substrate, coming from
       `substrate.AVAILABLE_SUBSTRATES`.
-    num_rollout_workers: The number of workers for playing games.
+    num_env_runners: The number of workers for playing games.
     rollout_fragment_length: Unroll time for learning.
     train_batch_size: Batch size (batch * rollout_fragment_length)
     fcnet_hiddens: Fully connected layers.
     post_fcnet_hiddens: Layer sizes after the fully connected torso.
     lstm_cell_size: Size of the LSTM.
-    sgd_minibatch_size: Size of the mini-batch for learning.
+    sgd_minibatch_size: Size of the sgd mini-batch for learning.
+    minibatch_size: Size of the mini-batch for learning.
 
   Returns:
     The configuration for running the experiment.
@@ -56,17 +58,19 @@ def get_config(
   # Gets the default training configuration
   config = ppo.PPOConfig()
   # Number of arenas.
-  config.num_rollout_workers = num_rollout_workers
+  config.num_env_runners = num_env_runners
   # This is to match our unroll lengths.
   config.rollout_fragment_length = rollout_fragment_length
   # Total (time x batch) timesteps on the learning update.
   config.train_batch_size = train_batch_size
-  # Mini-batch size.
+  # SGD Mini-batch size.
   config.sgd_minibatch_size = sgd_minibatch_size
+  # Mini-batch size
+  config.minibatch_size = minibatch_size
   # Use the raw observations/actions as defined by the environment.
   config.preprocessor_pref = None
-  # Use TensorFlow as the tensor framework.
-  config = config.framework("tf")
+  # Use TensorFlow 2 as the tensor framework.
+  config = config.framework("tf2")
   # Use GPUs iff `RLLIB_NUM_GPUS` env var set to > 0.
   config.num_gpus = int(os.environ.get("RLLIB_NUM_GPUS", "0"))
   config.log_level = "DEBUG"

--- a/examples/rllib/self_play_train_test.py
+++ b/examples/rllib/self_play_train_test.py
@@ -23,10 +23,11 @@ class TrainingTests(absltest.TestCase):
 
   def test_training(self):
     config = self_play_train.get_config(
-        num_rollout_workers=1,
+        num_env_runners=1,
         rollout_fragment_length=10,
         train_batch_size=20,
-        sgd_minibatch_size=20,
+        sgd_minibatch_size=10,
+        minibatch_size=10,
         fcnet_hiddens=(4,),
         post_fcnet_hiddens=(4,),
         lstm_cell_size=2)

--- a/examples/tutorial/requirements.in
+++ b/examples/tutorial/requirements.in
@@ -1,0 +1,5 @@
+# Requirements for tutorial examples
+absl_py
+dm_env
+dmlab2d
+numpy


### PR DESCRIPTION
<img width="810" alt="Screenshot 2025-04-14 at 3 33 37 PM" src="https://github.com/user-attachments/assets/8bedeee5-0dc6-432b-9c21-102996d8be9a" />

Using `ray[rllib,default]==2.5.0` causes an error when installing, presumably 2.5.0 is EOL.