### PR TITLE
Add headless example for commons_harvest substrate

### DIFF
--- a/examples/tutorial/harvest/README.md
+++ b/examples/tutorial/harvest/README.md
@@ -1,0 +1,8 @@
+## Headless Example
+
+`commons_harvest_headless.py` demonstrates how to run the
+`commons_harvest__open` substrate programmatically without a GUI.
+This is useful for servers, CI, and GitHub Codespaces.
+
+Note: Some TensorFlow/XLA initialization warnings may appear in headless
+environments and can be safely ignored.

--- a/examples/tutorial/harvest/commons_harvest_headless.py
+++ b/examples/tutorial/harvest/commons_harvest_headless.py
@@ -2,7 +2,6 @@
 # TensorFlow/XLA may emit initialization warnings in headless environments.
 # These are harmless and can be safely ignored.
 
-
 """
 Headless Harvest example for Melting Pot.
 

--- a/examples/tutorial/harvest/commons_harvest_headless.py
+++ b/examples/tutorial/harvest/commons_harvest_headless.py
@@ -1,0 +1,55 @@
+# NOTE:
+# TensorFlow/XLA may emit initialization warnings in headless environments.
+# These are harmless and can be safely ignored.
+
+
+"""
+Headless Harvest example for Melting Pot.
+
+This example demonstrates how to interact with the Harvest substrate
+programmatically without a graphical display.
+
+Notes:
+- Designed for headless environments (servers, CI, Codespaces)
+- Rewards may remain zero for many steps with naive policies
+- TensorFlow/XLA warnings may appear and can be safely ignored
+"""
+
+import os
+import random
+
+# This will suppress most of the Tensorflow logging (some early warnings are unavoidable)
+os.environ["TF_CPP_MIN_LOG_LEVEL"] = "3"
+os.environ["CUDA_VISIBLE_DEVICES"] = "-1"
+
+from meltingpot import substrate
+
+
+def main():
+    roles = ["default"] * 7
+    env = substrate.build("commons_harvest__open", roles=roles)
+
+    timestep = env.reset()
+
+    num_actions = env.action_spec()[0].num_values
+
+    print("Number of agents:", len(timestep.observation))
+    print("Number of actions per agent:", num_actions)
+    print("Observation keys:", timestep.observation[0].keys())
+
+    for step in range(20):
+        actions = [
+            random.randint(0, num_actions - 1)
+            for _ in range(len(timestep.observation))
+        ]
+
+        timestep = env.step(actions)
+
+        print(
+            f"Step {step + 1}",
+            "Rewards:", timestep.reward,
+        )
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
This PR adds a minimal headless example demonstrating how to interact with the
`commons_harvest__open` substrate programmatically without a graphical display.

Motivation:
- Existing tutorial examples rely on pygame and require a GUI
- New users running Melting Pot in headless environments (servers, CI, or
  GitHub Codespaces) lack a simple reference for stepping environments
- TensorFlow/XLA initialization warnings and sparse rewards can be confusing
  for first-time users

What this adds:
- A lightweight, headless example using `substrate.build`
- Random-action stepping to demonstrate observations and rewards
- Inline documentation explaining expected warnings and sparse rewards

Notes:
- Rewards are intentionally sparse and may remain zero for many steps
- TensorFlow/XLA initialization warnings may appear in headless environments
  and are harmless

No core logic is modified.
