### PR TITLE
Fix examples CI without optional RLlib dependencies

### DIFF
--- a/examples/gym/utils.py
+++ b/examples/gym/utils.py
@@ -13,6 +13,9 @@
 # limitations under the License.
 """Shared utils for third-party library examples."""
 
+# Gymnasium is an optional example dependency and absent from core CI.
+# pytype: disable=import-error
+
 from typing import Any, Mapping
 
 import dm_env

--- a/examples/rllib/self_play_train.py
+++ b/examples/rllib/self_play_train.py
@@ -13,6 +13,10 @@
 # limitations under the License.
 """Runs an example of a self-play training experiment."""
 
+# Ray and Gymnasium are optional example dependencies and absent from core CI.
+# pylint: disable=import-error
+# pytype: disable=import-error
+
 import os
 
 from meltingpot import substrate

--- a/examples/rllib/self_play_train_test.py
+++ b/examples/rllib/self_play_train_test.py
@@ -13,15 +13,33 @@
 # limitations under the License.
 """Tests for the self_play_train.py."""
 
+# Ray and Gymnasium are optional example dependencies and absent from core CI.
+# pylint: disable=import-error
+# pytype: disable=import-error
+
+import importlib.util
+import unittest
+
 from absl.testing import absltest
 
-from . import self_play_train
+def _module_available(module):
+  try:
+    return importlib.util.find_spec(module) is not None
+  except ModuleNotFoundError:
+    return False
 
 
+_RLLIB_AVAILABLE = all(
+    _module_available(module) for module in ('gymnasium', 'ray.rllib'))
+
+
+@unittest.skipUnless(_RLLIB_AVAILABLE, 'requires the optional RLlib extras')
 class TrainingTests(absltest.TestCase):
   """Tests for MeltingPotEnv for RLLib."""
 
   def test_training(self):
+    from . import self_play_train  # pylint: disable=g-import-not-at-top
+
     config = self_play_train.get_config(
         num_rollout_workers=1,
         rollout_fragment_length=10,

--- a/examples/rllib/utils.py
+++ b/examples/rllib/utils.py
@@ -13,6 +13,10 @@
 # limitations under the License.
 """MeltingPotEnv as a MultiAgentEnv wrapper to interface with RLLib."""
 
+# Ray and Gymnasium are optional example dependencies and absent from core CI.
+# pylint: disable=import-error
+# pytype: disable=import-error
+
 from typing import Tuple
 
 import dm_env

--- a/examples/rllib/utils_test.py
+++ b/examples/rllib/utils_test.py
@@ -13,33 +13,56 @@
 # limitations under the License.
 """Tests for utils.py."""
 
+# Ray and Gymnasium are optional example dependencies and absent from core CI.
+# pylint: disable=import-error
+# pytype: disable=import-error
+
+import importlib.util
+import unittest
+
 from absl.testing import absltest
-from gymnasium.spaces import discrete
-from meltingpot import substrate
-from meltingpot.configs.substrates import commons_harvest__open
 
-from . import utils
+def _module_available(module):
+  try:
+    return importlib.util.find_spec(module) is not None
+  except ModuleNotFoundError:
+    return False
 
 
+_RLLIB_AVAILABLE = all(
+    _module_available(module) for module in ('gymnasium', 'ray.rllib'))
+
+
+@unittest.skipUnless(_RLLIB_AVAILABLE, 'requires the optional RLlib extras')
 class MeltingPotEnvTests(absltest.TestCase):
   """Tests for MeltingPotEnv for RLLib."""
 
   def setUp(self):
     super().setUp()
+    from gymnasium.spaces import discrete  # pylint: disable=g-import-not-at-top
+    from meltingpot import substrate  # pylint: disable=g-import-not-at-top
+    from meltingpot.configs.substrates import (  # pylint: disable=g-import-not-at-top
+        commons_harvest__open)
+    from . import utils  # pylint: disable=g-import-not-at-top
+
+    self._discrete = discrete
+    self._substrate = substrate
+    self._substrate_config = commons_harvest__open
+    self._utils = utils
     # Create a new MeltingPotEnv for each test case
-    env_config = substrate.get_config('commons_harvest__open')
+    env_config = self._substrate.get_config('commons_harvest__open')
     roles = env_config.default_player_roles
     self._num_players = len(roles)
-    self._env = utils.env_creator({
+    self._env = self._utils.env_creator({
         'substrate': 'commons_harvest__open',
         'roles': roles,
     })
 
   def test_action_space_size(self):
     """Test the action space is the correct size."""
-    actions_count = len(commons_harvest__open.ACTION_SET)
+    actions_count = len(self._substrate_config.ACTION_SET)
     env_action_space = self._env.action_space['player_1']
-    self.assertEqual(env_action_space, discrete.Discrete(actions_count))
+    self.assertEqual(env_action_space, self._discrete.Discrete(actions_count))
 
   def test_reset_number_agents(self):
     """Test that reset() returns observations for all agents."""

--- a/examples/rllib/view_models.py
+++ b/examples/rllib/view_models.py
@@ -17,6 +17,10 @@ You must provide experiment_state, expected to be
 ~/ray_results/PPO/experiment_state_YOUR_RUN_ID.json
 """
 
+# Ray and Gymnasium are optional example dependencies and absent from core CI.
+# pylint: disable=import-error
+# pytype: disable=import-error
+
 import argparse
 
 import dm_env


### PR DESCRIPTION
## Summary
- collect RLlib tests normally and skip them at class level when the optional Gymnasium/RLlib extras are unavailable
- defer optional imports until skipped tests actually run, avoiding collection failures
- scope lint and type-check import diagnostics in RLlib-only modules to their intentionally optional dependencies

This keeps the required examples workflow successful without making the large RLlib dependency set part of the core installation.

Fixes #316

## Testing
- `python -m pytest examples/rllib -q`: 6 skipped, exit code 0
- `pylint --errors-only examples/rllib`: passed
