### PR TITLE
Handle empty example test collection in CI

### DIFF
--- a/.github/workflows/test-examples.yml
+++ b/.github/workflows/test-examples.yml
@@ -49,7 +49,16 @@ jobs:
         uses: ./.github/actions/install
 
       - name: Test examples
-        run: pytest examples
+        run: |
+          set +e
+          pytest examples
+          status=$?
+          set -e
+          if [ "$status" -eq 5 ]; then
+            echo "No example tests were collected."
+            exit 0
+          fi
+          exit "$status"
 
       - name: Lint examples
         run: pylint --errors-only examples

--- a/.github/workflows/test-examples.yml
+++ b/.github/workflows/test-examples.yml
@@ -9,6 +9,7 @@ on:
       - '.github/workflows/test-examples.yml'
       - '.pylintrc'
       - 'bin/install.sh'
+      - 'bin/test_examples.sh'
       - 'examples/**'
       - 'meltingpot/**'
       - 'pyproject.toml'
@@ -23,6 +24,7 @@ on:
       - '.pylintrc'
       - '.python-version'
       - 'bin/install.sh'
+      - 'bin/test_examples.sh'
       - 'examples/**'
       - 'meltingpot/**'
       - 'pyproject.toml'
@@ -49,16 +51,7 @@ jobs:
         uses: ./.github/actions/install
 
       - name: Test examples
-        run: |
-          set +e
-          pytest examples
-          status=$?
-          set -e
-          if [ "$status" -eq 5 ]; then
-            echo "No example tests were collected."
-            exit 0
-          fi
-          exit "$status"
+        run: bash bin/test_examples.sh
 
       - name: Lint examples
         run: pylint --errors-only examples


### PR DESCRIPTION
## Summary

Keep the `test-examples` workflow green when `examples/` contains no pytest tests, while still failing on real collection or test errors.

The repository now has `bin/test_examples.sh`, which already treats pytest's exit status 5 (`NO_TESTS_COLLECTED`) as success. The GitHub Actions workflow still invokes `pytest examples` directly, so unrelated pull requests continue to get a false-red `test-examples` check when no tests are collected.

This change:
- runs the existing `bin/test_examples.sh` helper from the workflow
- adds that helper to the workflow path filters
- leaves lint and typecheck steps unchanged

Fixes #316.

## Validation

GitHub Actions on the current head:
- `test-examples`: passed
- CodeQL: passed
- Google GitHub Admin Actions Workflow Security Scan: passed

The PR remains limited to `.github/workflows/test-examples.yml`.
