### PR TITLE
Fix malformed PyPI link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ If you are interested in extending Melting Pot, please refer to the
 
 ## Installation
 
-Melting Pot is available on PyPI](https://pypi.python.org/pypi/dm-meltingpot)
+Melting Pot is available on [PyPI](https://pypi.python.org/pypi/dm-meltingpot)
 and can be installed using:
 
 ```shell


### PR DESCRIPTION
## Summary

Fix the malformed Markdown link for PyPI in the README installation section.

The current text is missing the opening `[` before `PyPI`, so the package link does not render correctly.

The earlier version of this PR also corrected an RLlib example installation path. Those RLlib examples have since been removed from `main`, so that obsolete change has been removed from this branch.

No linked issue; this is a self-contained README rendering fix.

## Validation

Rebased onto current `main` as a single focused commit (`16598a83727330aed6664a05cdae5958f0206f82`).

The final diff changes exactly one line in `README.md`, with 1 addition and 1 deletion.

CodeQL and the Google GitHub Admin Actions Workflow Security Scan both pass. No runtime code is changed.