### PR TITLE
Update bot extension examples to current API

### DIFF
--- a/docs/extending.md
+++ b/docs/extending.md
@@ -17,19 +17,20 @@ Add your bots to the library by adding an entry for each one in [`bots`](https:/
 If your bot is purely a saved model then structure its entry like this:
 
 ```python
-my_bot_0=_saved_model(
+my_bot_0=saved_model(
     substrate='name_of_substrate_where_bot_operates',
     model='my_bot_0',
 ),
 ```
 
 If instead your bot is a puppet, then select a `Puppeteer` from those
-defined in [`puppeteers`](https://github.com/google-deepmind/meltingpot/tree/main/meltingpot/utils/bots/puppeteers).
+defined in [`puppeteers`](https://github.com/google-deepmind/meltingpot/tree/main/meltingpot/utils/puppeteers).
 Then structure its bot entry like this:
 
 ```python
-my_puppet_bot_0=_puppet(
+my_puppet_bot_0=puppet(
     substrate='name_of_substrate_where_bot_operates',
+    model='my_puppet_bot_0',
     puppeteer_builder=functools.partial(Puppeteer, **kwargs)
 ),
 ```


### PR DESCRIPTION
## Summary

Bring the bot extension examples in `docs/extending.md` in line with the current `meltingpot.configs.bots` API.

This change:

* uses the current `saved_model` and `puppet` helpers instead of the stale `_saved_model` and `_puppet` names
* adds the required `model` argument to the puppet example
* updates the puppeteer link to the current `meltingpot/utils/puppeteers` location

## Testing

Documentation-only change. Checked the examples against the current bot helper signatures and repository paths.
