### PR TITLE
Handle ASCII maps without a leading newline

### DIFF
--- a/meltingpot/utils/substrates/game_object_utils.py
+++ b/meltingpot/utils/substrates/game_object_utils.py
@@ -202,9 +202,9 @@ def get_game_object_positions_from_map(
   """
   transforms = []
   rows = ascii_map.split("\n")
-  # Assume the first line of the string consists only of '\n'. This means we
-  # need to skip the first row.
-  for i, row in enumerate(rows[1:]):
+  if rows and not rows[0]:
+    rows = rows[1:]
+  for i, row in enumerate(rows):
     indices = [i for i, c in enumerate(row) if char == c]
     for j in indices:
       if orientation_mode == "always_north":

--- a/meltingpot/utils/substrates/game_object_utils_no_leading_newline_test.py
+++ b/meltingpot/utils/substrates/game_object_utils_no_leading_newline_test.py
@@ -1,0 +1,48 @@
+# Copyright 2026 DeepMind Technologies Limited.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Regression tests for ASCII maps without a leading newline."""
+
+from absl.testing import absltest
+from meltingpot.utils.substrates import game_object_utils
+
+
+class ParseMapWithoutLeadingNewlineTest(absltest.TestCase):
+
+  def test_first_row_is_not_skipped(self):
+    transforms = game_object_utils.get_game_object_positions_from_map(
+        'A..\n...', 'A')
+
+    self.assertEqual(
+        transforms,
+        [game_object_utils.Transform(
+            position=game_object_utils.Position(0, 0),
+            orientation=game_object_utils.Orientation.NORTH,
+        )],
+    )
+
+  def test_existing_leading_newline_behavior_is_preserved(self):
+    transforms = game_object_utils.get_game_object_positions_from_map(
+        '\nA..\n...', 'A')
+
+    self.assertEqual(
+        transforms,
+        [game_object_utils.Transform(
+            position=game_object_utils.Position(0, 0),
+            orientation=game_object_utils.Orientation.NORTH,
+        )],
+    )
+
+
+if __name__ == '__main__':
+  absltest.main()


### PR DESCRIPTION
## Summary

Fix `get_game_object_positions_from_map` so ASCII maps passed without an initial newline keep their first row.

The helper previously always skipped `rows[0]`, based on an assumption that map strings begin with a blank line. Callers using ordinary strings such as `A..\n...` therefore lost every object on the first row.

This change:
- skips the first row only when it is actually empty
- preserves the existing behavior for triple-quoted maps with a leading newline
- adds regression coverage for both forms

## Testing

Added focused regression tests for maps with and without a leading newline.