### PR TITLE
Correct public scenario and substrate API docstrings

### DIFF
--- a/meltingpot/configs/substrates/__init__.py
+++ b/meltingpot/configs/substrates/__init__.py
@@ -55,7 +55,7 @@ def get_config(substrate: str) -> config_dict.ConfigDict:
     substrate: the name of the substrate. Must be in SUBSTRATES.
 
   Raises:
-    ModuleNotFoundError: the config does not exist.
+    ValueError: the substrate is not in SUBSTRATES.
   """
   if substrate not in SUBSTRATES:
     raise ValueError(f'{substrate} not in {SUBSTRATES}.')

--- a/meltingpot/scenario.py
+++ b/meltingpot/scenario.py
@@ -94,7 +94,7 @@ def build_from_config(
   """Builds a scenario from the provided config.
 
   Args:
-    config: bot config
+    config: scenario config.
     substrate_transform: optional transform to apply to underlying substrate.
       This is intended for training purposes and should not be used during
       evaluation. If applied, the observations will not be restricted to


### PR DESCRIPTION
## Summary

Correct stale or inaccurate public API docstrings.

- `scenario.build_from_config` described its `config` parameter as a bot config; it is a scenario config.
- `configs.substrates.get_config` documented `ModuleNotFoundError` for an invalid substrate, while the function explicitly raises `ValueError`.

No runtime behavior is changed.

## Testing

Documentation-only change.