### PR TITLE
Preserve pip-compile argument boundaries

### DIFF
--- a/bin/update_requirements.sh
+++ b/bin/update_requirements.sh
@@ -20,4 +20,4 @@
 set -euxo pipefail
 cd "$(dirname "$0")/.."
 
-pip-compile $@ --all-extras setup.py examples/requirements.in
+pip-compile "$@" --all-extras setup.py examples/requirements.in


### PR DESCRIPTION
## Summary

Quote `"$@"` when forwarding command-line arguments from `bin/update_requirements.sh` to `pip-compile`.

The unquoted expansion can split individual arguments on whitespace and apply shell glob expansion before `pip-compile` receives them. Quoted `"$@"` preserves each caller-supplied argument exactly while still expanding to zero arguments when none are provided.

## Testing

Shell-only change. The standard `"$@"` expansion preserves argument boundaries without changing the existing no-argument or `--upgrade` usage.