### PR TITLE
Validate procedural map helper odds

### DIFF
--- a/meltingpot/utils/substrates/map_helpers.py
+++ b/meltingpot/utils/substrates/map_helpers.py
@@ -14,6 +14,7 @@
 """Tools to help with parsing and procedurally generating ascii maps."""
 
 from collections.abc import Mapping, Sequence
+import numbers
 from typing import Any, Union
 
 
@@ -35,7 +36,19 @@ def a_or_b_with_odds(a_descriptor: Union[str, Mapping[str, Any]],
   Returns:
       The dict descriptor that can be used with the map parser to sample either
       a or b at the specified odds.
+
+  Raises:
+      ValueError: If odds does not contain exactly two non-negative integer
+          values, or if both values are zero.
   """
+  if len(odds) != 2:
+    raise ValueError('odds must contain exactly two values.')
+  if any(not isinstance(value, numbers.Integral) for value in odds):
+    raise ValueError('odds values must be integers.')
   a_odds, b_odds = odds
+  if a_odds < 0 or b_odds < 0:
+    raise ValueError('odds values must be non-negative.')
+  if a_odds + b_odds == 0:
+    raise ValueError('At least one odds value must be positive.')
   choices = [a_descriptor] * a_odds + [b_descriptor] * b_odds
   return {"type": "choice", "list": choices}

--- a/meltingpot/utils/substrates/map_helpers_test.py
+++ b/meltingpot/utils/substrates/map_helpers_test.py
@@ -1,0 +1,43 @@
+# Copyright 2026 DeepMind Technologies Limited.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Tests for map_helpers."""
+
+from absl.testing import absltest
+from absl.testing import parameterized
+from meltingpot.utils.substrates import map_helpers
+
+
+class MapHelpersTest(parameterized.TestCase):
+
+  def test_a_or_b_with_odds(self):
+    self.assertEqual(
+        map_helpers.a_or_b_with_odds('a', 'b', (2, 1)),
+        {'type': 'choice', 'list': ['a', 'a', 'b']})
+
+  @parameterized.parameters(
+      (),
+      (1,),
+      (1, 2, 3),
+      (-1, 1),
+      (1, -1),
+      (0, 0),
+      (1.5, 1),
+  )
+  def test_a_or_b_with_odds_rejects_invalid_odds(self, odds):
+    with self.assertRaises(ValueError):
+      map_helpers.a_or_b_with_odds('a', 'b', odds)
+
+
+if __name__ == '__main__':
+  absltest.main()


### PR DESCRIPTION
## Summary

Validate the odds supplied to `a_or_b_with_odds` before constructing a procedural map choice descriptor.

Negative odds currently produce misleading choice lists because Python treats negative list repetition as an empty list. `(0, 0)` produces an empty choice list that only fails later when the map parser tries to sample from it.

This change:
- requires exactly two integer odds values
- rejects negative values
- requires at least one positive value
- documents the validation behavior
- adds focused unit tests for valid and invalid inputs

## Testing

Added `map_helpers_test.py` covering normal weighted choices, wrong-length odds, negative values, all-zero odds, and non-integer odds.