### PR TITLE
Validate discrete actions before table lookup

### DIFF
--- a/meltingpot/utils/substrates/wrappers/discrete_action_wrapper.py
+++ b/meltingpot/utils/substrates/wrappers/discrete_action_wrapper.py
@@ -96,6 +96,17 @@ class Wrapper(observables.ObservableLab2dWrapper):
 
   def step(self, action: Sequence[int]):
     """See base class."""
+    action_spec = self.action_spec()
+    if len(action) != len(action_spec):
+      raise ValueError(
+          f'Expected {len(action_spec)} player actions, got {len(action)}.')
+    for player_index, (player_action, spec) in enumerate(
+        zip(action, action_spec)):
+      try:
+        spec.validate(player_action)
+      except ValueError:
+        raise ValueError(
+            f'Invalid action {player_action!r} for player {player_index}.') from None
     action = [self._action_table[player_action] for player_action in action]  # pyrefly: ignore[bad-assignment]
     return super().step(action)
 

--- a/meltingpot/utils/substrates/wrappers/discrete_action_wrapper.py
+++ b/meltingpot/utils/substrates/wrappers/discrete_action_wrapper.py
@@ -14,6 +14,7 @@
 """Wrapper that converts action dictionary to a one hot vector."""
 
 import functools
+import operator
 from typing import Mapping, Sequence, TypeVar, Union
 
 import dm_env
@@ -99,16 +100,17 @@ class Wrapper(observables.ObservableLab2dWrapper):
     action_spec = self.action_spec()
     if len(action) != len(action_spec):
       raise ValueError(
-          f'Expected {len(action_spec)} player actions, got {len(action)}.')
-    for player_index, (player_action, spec) in enumerate(
-        zip(action, action_spec)):
-      try:
-        spec.validate(player_action)
-      except ValueError:
+          f'Expected {len(action_spec)} player actions, got {len(action)}.'
+      )
+    mapped_actions = []
+    for player_index, player_action in enumerate(action):
+      action_index = operator.index(player_action)
+      if not 0 <= action_index < len(self._action_table):
         raise ValueError(
-            f'Invalid action {player_action!r} for player {player_index}.') from None
-    action = [self._action_table[player_action] for player_action in action]  # pyrefly: ignore[bad-assignment]
-    return super().step(action)
+            f'Invalid action {player_action!r} for player {player_index}.'
+        )
+      mapped_actions.append(self._action_table[action_index])
+    return super().step(mapped_actions)
 
   @functools.lru_cache(maxsize=1)
   def action_spec(self) -> Sequence[dm_env.specs.DiscreteArray]:

--- a/meltingpot/utils/substrates/wrappers/discrete_action_wrapper_test.py
+++ b/meltingpot/utils/substrates/wrappers/discrete_action_wrapper_test.py
@@ -101,6 +101,39 @@ class Lab2DToListsWrapperTest(parameterized.TestCase):
           {'MOVE': VALID_VALUE_1, 'TURN': VALID_VALUE_0},
       ])
 
+  @parameterized.parameters(-1, 3)
+  def test_step_rejects_out_of_range_action(self, invalid_action):
+    env = mock.Mock(spec_set=dmlab2d.Environment)
+    env.action_spec.return_value = [
+        {'MOVE': MOVE_SPEC, 'TURN': TURN_SPEC},
+        {'MOVE': MOVE_SPEC, 'TURN': TURN_SPEC},
+    ]
+    wrapped = discrete_action_wrapper.Wrapper(env, action_table=[
+        {'MOVE': VALID_VALUE_0, 'TURN': VALID_VALUE_0},
+        {'MOVE': VALID_VALUE_0, 'TURN': VALID_VALUE_1},
+        {'MOVE': VALID_VALUE_1, 'TURN': VALID_VALUE_0},
+    ])
+
+    with self.assertRaises(ValueError):
+      wrapped.step([0, invalid_action])
+    env.step.assert_not_called()
+
+  def test_step_rejects_wrong_player_count(self):
+    env = mock.Mock(spec_set=dmlab2d.Environment)
+    env.action_spec.return_value = [
+        {'MOVE': MOVE_SPEC, 'TURN': TURN_SPEC},
+        {'MOVE': MOVE_SPEC, 'TURN': TURN_SPEC},
+    ]
+    wrapped = discrete_action_wrapper.Wrapper(env, action_table=[
+        {'MOVE': VALID_VALUE_0, 'TURN': VALID_VALUE_0},
+        {'MOVE': VALID_VALUE_0, 'TURN': VALID_VALUE_1},
+        {'MOVE': VALID_VALUE_1, 'TURN': VALID_VALUE_0},
+    ])
+
+    with self.assertRaises(ValueError):
+      wrapped.step([0])
+    env.step.assert_not_called()
+
 
 if __name__ == '__main__':
   absltest.main()

--- a/meltingpot/utils/substrates/wrappers/discrete_action_wrapper_test.py
+++ b/meltingpot/utils/substrates/wrappers/discrete_action_wrapper_test.py
@@ -78,7 +78,13 @@ class Lab2DToListsWrapperTest(parameterized.TestCase):
     ) * 2
     self.assertEqual(actual, expected)
 
-  def test_step(self):
+  @parameterized.named_parameters(
+      ('python_int', int),
+      ('numpy_int32', np.int32),
+      ('numpy_int64', np.int64),
+      ('numpy_scalar_array', np.asarray),
+  )
+  def test_step(self, action_type):
     env = mock.Mock(spec_set=dmlab2d.Environment)
     env.action_spec.return_value = [
         {'MOVE': MOVE_SPEC, 'TURN': TURN_SPEC},
@@ -90,7 +96,7 @@ class Lab2DToListsWrapperTest(parameterized.TestCase):
         {'MOVE': VALID_VALUE_0, 'TURN': VALID_VALUE_1},
         {'MOVE': VALID_VALUE_1, 'TURN': VALID_VALUE_0},
     ])
-    actual = wrapped.step([0, 2])
+    actual = wrapped.step([action_type(0), action_type(2)])
 
     with self.subTest('timestep'):
       np.testing.assert_equal(actual, mock.sentinel.timestep)
@@ -118,7 +124,12 @@ class Lab2DToListsWrapperTest(parameterized.TestCase):
       wrapped.step([0, invalid_action])
     env.step.assert_not_called()
 
-  def test_step_rejects_wrong_player_count(self):
+  @parameterized.named_parameters(
+      ('empty', []),
+      ('too_few', [0]),
+      ('too_many', [0, 1, 2]),
+  )
+  def test_step_rejects_wrong_player_count(self, actions):
     env = mock.Mock(spec_set=dmlab2d.Environment)
     env.action_spec.return_value = [
         {'MOVE': MOVE_SPEC, 'TURN': TURN_SPEC},
@@ -131,7 +142,30 @@ class Lab2DToListsWrapperTest(parameterized.TestCase):
     ])
 
     with self.assertRaises(ValueError):
-      wrapped.step([0])
+      wrapped.step(actions)
+    env.step.assert_not_called()
+
+  @parameterized.named_parameters(
+      ('float', 1.0),
+      ('string', '1'),
+      ('non_scalar_array', np.array([1])),
+  )
+  def test_step_rejects_non_integer_action(self, invalid_action):
+    env = mock.Mock(spec_set=dmlab2d.Environment)
+    env.action_spec.return_value = [
+        {'MOVE': MOVE_SPEC, 'TURN': TURN_SPEC},
+        {'MOVE': MOVE_SPEC, 'TURN': TURN_SPEC},
+    ]
+    wrapped = discrete_action_wrapper.Wrapper(
+        env,
+        action_table=[
+            {'MOVE': VALID_VALUE_0, 'TURN': VALID_VALUE_0},
+            {'MOVE': VALID_VALUE_0, 'TURN': VALID_VALUE_1},
+        ],
+    )
+
+    with self.assertRaises(TypeError):
+      wrapped.step([0, invalid_action])
     env.step.assert_not_called()
 
 


### PR DESCRIPTION
Reject negative and out-of-range discrete actions, and incorrect player counts, before forwarding actions to the environment. Previously, `-1` silently selected the last action-table entry.

Use scalar integer-index and bounds checks while mapping actions in one pass. This avoids per-step NumPy spec validation and preserves support for Python integers, NumPy integer scalars, and scalar integer arrays. Non-integer indices raise `TypeError` without stepping the environment.

## Validation

`python -m pytest -q -n 0 meltingpot/utils/substrates/wrappers`

42 tests and 37 subtests passed, including the expanded discrete-action regressions. The new tests reproduce the missing bounds/player-count validation against unpatched upstream code.

For eight players, a wrapper-only microbenchmark measured 10.78 microseconds per step for the earlier full-spec validation, 0.45 microseconds for this revision, and 0.23 microseconds for unvalidated upstream code. These are medians of five repeats of 5,000 calls on arm64, Python 3.11.16, NumPy 2.4.6, with a no-op environment; they are not simulator-throughput measurements.
