### PR TITLE
Support prefab overrides for components without kwargs

### DIFF
--- a/meltingpot/utils/substrates/builder.py
+++ b/meltingpot/utils/substrates/builder.py
@@ -82,9 +82,11 @@ def apply_prefab_overrides(
           if prefab not in lab2d_settings.simulation.prefabs:
             raise ValueError(f"Prefab override for '{prefab}' given, but not " +
                              "available in `prefabs`.")
-          game_object_utils.get_first_named_component(
-              lab2d_settings.simulation.prefabs[prefab],
-              component)["kwargs"][arg_name] = arg_override
+          component_config = game_object_utils.get_first_named_component(
+              lab2d_settings.simulation.prefabs[prefab], component)
+          if "kwargs" not in component_config:
+            component_config["kwargs"] = {}
+          component_config["kwargs"][arg_name] = arg_override
 
 
 def maybe_build_and_add_avatar_objects(

--- a/meltingpot/utils/substrates/builder_prefab_override_test.py
+++ b/meltingpot/utils/substrates/builder_prefab_override_test.py
@@ -1,0 +1,52 @@
+# Copyright 2026 DeepMind Technologies Limited.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Tests for prefab overrides in the substrate builder."""
+
+from absl.testing import absltest
+from meltingpot.utils.substrates import builder
+from ml_collections import config_dict
+
+
+class PrefabOverrideTest(absltest.TestCase):
+
+  def test_override_adds_missing_kwargs_mapping(self):
+    lab2d_settings = config_dict.ConfigDict({
+        'simulation': {
+            'prefabs': {
+                'item': {
+                    'components': [
+                        {'component': 'Transform'},
+                    ],
+                },
+            },
+        },
+    }).unlock()
+
+    builder.apply_prefab_overrides(
+        lab2d_settings,
+        prefab_overrides={
+            'item': {
+                'Transform': {
+                    'orientation': 'E',
+                },
+            },
+        },
+    )
+
+    component = lab2d_settings.simulation.prefabs.item.components[0]
+    self.assertEqual(component.kwargs.orientation, 'E')
+
+
+if __name__ == '__main__':
+  absltest.main()


### PR DESCRIPTION
## Summary

Allow prefab overrides to target components whose configuration omits the optional `kwargs` mapping.

Component configurations may omit `kwargs`, for example a simple `Transform` component can be declared as `{"component": "Transform"}`. `apply_prefab_overrides` currently indexes `["kwargs"]` unconditionally, so overriding such a component raises `KeyError`.

This change:
- creates an empty `kwargs` mapping when the target component does not already have one
- applies the requested override through the same path as existing components with kwargs
- adds a focused regression test using a kwargs-free `Transform` component

## Testing

Added `builder_prefab_override_test.py` covering an override on a component with no pre-existing `kwargs` field.