### PR TITLE
Reject duplicate puppet goal names

### DIFF
--- a/meltingpot/utils/puppeteers/puppeteer.py
+++ b/meltingpot/utils/puppeteers/puppeteer.py
@@ -71,9 +71,14 @@ def puppet_goals(
   """Returns a mapping from goal name to a one-hot goal vector for a puppet.
 
   Args:
-    names: names for each of the corresponding goals.
+    names: names for each of the corresponding goals. Names must be unique.
     dtype: dtype of the one-hot goals to return.
+
+  Raises:
+    ValueError: If duplicate goal names are provided.
   """
+  if len(set(names)) != len(names):
+    raise ValueError('Puppet goal names must be unique.')
   goals = np.eye(len(names), dtype=dtype)
   goals.setflags(write=False)
   return immutabledict.immutabledict(zip(names, goals))

--- a/meltingpot/utils/puppeteers/puppeteer_test.py
+++ b/meltingpot/utils/puppeteers/puppeteer_test.py
@@ -1,0 +1,36 @@
+# Copyright 2026 DeepMind Technologies Limited.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Tests for puppeteer helpers."""
+
+from absl.testing import absltest
+from meltingpot.utils.puppeteers import puppeteer
+import numpy as np
+
+
+class PuppetGoalsTest(absltest.TestCase):
+
+  def test_rejects_duplicate_names(self):
+    with self.assertRaisesRegex(ValueError, 'must be unique'):
+      puppeteer.puppet_goals(['collect', 'collect'])
+
+  def test_unique_names_keep_one_to_one_goals(self):
+    goals = puppeteer.puppet_goals(['collect', 'deposit'])
+
+    self.assertEqual(tuple(goals), ('collect', 'deposit'))
+    np.testing.assert_array_equal(goals['collect'], [1, 0])
+    np.testing.assert_array_equal(goals['deposit'], [0, 1])
+
+
+if __name__ == '__main__':
+  absltest.main()


### PR DESCRIPTION
## Summary

Reject duplicate names passed to `puppet_goals`.

`puppet_goals` builds one-hot vectors and then constructs a mapping with `zip(names, goals)`. Duplicate names are silently collapsed by the mapping, so the returned mapping no longer has a one-to-one correspondence with the generated goal vectors.

This change:
- requires puppet goal names to be unique
- raises a clear `ValueError` for duplicate names
- documents the uniqueness requirement
- adds tests for duplicate rejection and the normal one-to-one mapping

## Testing

Added focused unit tests for duplicate and unique puppet goal names.