### PR TITLE
Validate avatar and badge palette counts

### DIFF
--- a/meltingpot/utils/substrates/game_object_utils.py
+++ b/meltingpot/utils/substrates/game_object_utils.py
@@ -92,9 +92,17 @@ def build_avatar_objects(
     raise ValueError(
         "Building avatar objects requested, but no avatar prefab provided.")
 
-  if not player_palettes:
+  if player_palettes is None or len(player_palettes) == 0:
+    if num_players > len(colors.palette):
+      raise ValueError(
+          f"Cannot generate {num_players} default player palettes; only "
+          f"{len(colors.palette)} colors are available.")
     player_palettes = [  # pyrefly: ignore[bad-assignment]
         shapes.get_palette(colors.palette[i]) for i in range(num_players)]
+  elif len(player_palettes) < num_players:
+    raise ValueError(
+        f"Expected at least {num_players} player palettes, got "
+        f"{len(player_palettes)}.")
 
   avatar_objects = []
   for idx in range(0, num_players):
@@ -139,9 +147,17 @@ def build_avatar_badges(
         "provided.")
   game_objects = []
 
-  if badge_palettes is None:
+  if badge_palettes is None or len(badge_palettes) == 0:
+    if num_players > len(colors.palette):
+      raise ValueError(
+          f"Cannot generate {num_players} default badge palettes; only "
+          f"{len(colors.palette)} colors are available.")
     badge_palettes = [  # pyrefly: ignore[bad-assignment]
         shapes.get_palette(colors.palette[i]) for i in range(num_players)]
+  elif len(badge_palettes) < num_players:
+    raise ValueError(
+        f"Expected at least {num_players} badge palettes, got "
+        f"{len(badge_palettes)}.")
 
   for idx in range(0, num_players):
     lua_index = idx + 1

--- a/meltingpot/utils/substrates/game_object_utils_palette_test.py
+++ b/meltingpot/utils/substrates/game_object_utils_palette_test.py
@@ -1,0 +1,53 @@
+# Copyright 2026 DeepMind Technologies Limited.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Regression tests for avatar palette count validation."""
+
+from absl.testing import absltest
+from meltingpot.utils.substrates import colors
+from meltingpot.utils.substrates import game_object_utils
+from meltingpot.utils.substrates import shapes
+
+
+class PaletteCountValidationTest(absltest.TestCase):
+
+  def test_rejects_too_few_player_palettes(self):
+    palette = shapes.get_palette(colors.palette[0])
+
+    with self.assertRaisesRegex(ValueError, 'player palettes'):
+      game_object_utils.build_avatar_objects(
+          num_players=2,
+          prefabs={'avatar': {}},
+          player_palettes=[palette],
+      )
+
+  def test_rejects_too_few_badge_palettes(self):
+    palette = shapes.get_palette(colors.palette[0])
+
+    with self.assertRaisesRegex(ValueError, 'badge palettes'):
+      game_object_utils.build_avatar_badges(
+          num_players=2,
+          prefabs={'avatar_badge': {}},
+          badge_palettes=[palette],
+      )
+
+  def test_rejects_too_many_players_for_default_palette(self):
+    with self.assertRaisesRegex(ValueError, 'default player palettes'):
+      game_object_utils.build_avatar_objects(
+          num_players=len(colors.palette) + 1,
+          prefabs={'avatar': {}},
+      )
+
+
+if __name__ == '__main__':
+  absltest.main()

--- a/meltingpot/utils/substrates/game_object_utils_palette_test.py
+++ b/meltingpot/utils/substrates/game_object_utils_palette_test.py
@@ -16,13 +16,12 @@
 from absl.testing import absltest
 from meltingpot.utils.substrates import colors
 from meltingpot.utils.substrates import game_object_utils
-from meltingpot.utils.substrates import shapes
 
 
 class PaletteCountValidationTest(absltest.TestCase):
 
   def test_rejects_too_few_player_palettes(self):
-    palette = shapes.get_palette(colors.palette[0])
+    palette = (255, 0, 0, 255)
 
     with self.assertRaisesRegex(ValueError, 'player palettes'):
       game_object_utils.build_avatar_objects(
@@ -32,7 +31,7 @@ class PaletteCountValidationTest(absltest.TestCase):
       )
 
   def test_rejects_too_few_badge_palettes(self):
-    palette = shapes.get_palette(colors.palette[0])
+    palette = (255, 0, 0, 255)
 
     with self.assertRaisesRegex(ValueError, 'badge palettes'):
       game_object_utils.build_avatar_badges(


### PR DESCRIPTION
## Summary

Validate player and badge palette counts before building avatar objects.

When a caller supplies fewer palettes than `num_players`, avatar construction currently fails later with an opaque `IndexError`. The same problem exists for badge palettes. Default palette generation can also run past the finite built-in color table when the player count is too large.

This change:
- rejects non-empty player palette lists shorter than `num_players`
- rejects non-empty badge palette lists shorter than `num_players`
- reports a clear error when the built-in palette cannot cover the requested player count
- preserves the existing behavior where `None` or an empty palette sequence selects default palettes
- adds focused regression tests

## Testing

Added tests for short player palettes, short badge palettes, and player counts exceeding the built-in default palette capacity.