### PR TITLE
Validate focal action count before scenario merge

### DIFF
--- a/meltingpot/utils/scenarios/scenario.py
+++ b/meltingpot/utils/scenarios/scenario.py
@@ -157,6 +157,11 @@ class Scenario(substrate_lib.Substrate):
 
   def _await_full_action(self, focal_action: Sequence[int]) -> Sequence[int]:
     """Returns full action after awaiting bot actions."""
+    expected_num_focal_actions = sum(self._is_focal)
+    if len(focal_action) != expected_num_focal_actions:
+      raise ValueError(
+          f'Expected {expected_num_focal_actions} focal actions, got '
+          f'{len(focal_action)}.')
     self._focal_action_subject.on_next(focal_action)
     background_action = self._background_population.await_action()
     return _merge(focal_action, background_action, self._is_focal)

--- a/meltingpot/utils/scenarios/scenario_action_validation_test.py
+++ b/meltingpot/utils/scenarios/scenario_action_validation_test.py
@@ -1,0 +1,39 @@
+# Copyright 2026 DeepMind Technologies Limited.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Regression tests for focal action count validation."""
+
+from unittest import mock
+
+from absl.testing import parameterized
+from meltingpot.utils.scenarios import scenario as scenario_utils
+
+
+class ScenarioActionValidationTest(parameterized.TestCase):
+
+  @parameterized.parameters([0], [1], [0, 1, 2])
+  def test_rejects_wrong_number_of_focal_actions(self, focal_action):
+    scenario = object.__new__(scenario_utils.Scenario)
+    scenario._is_focal = (True, False, True)
+    scenario._focal_action_subject = mock.Mock()
+    scenario._background_population = mock.Mock()
+
+    with self.assertRaisesRegex(ValueError, 'Expected 2 focal actions'):
+      scenario._await_full_action(focal_action)
+
+    scenario._focal_action_subject.on_next.assert_not_called()
+    scenario._background_population.await_action.assert_not_called()
+
+
+if __name__ == '__main__':
+  parameterized.absltest.main()

--- a/meltingpot/utils/scenarios/scenario_action_validation_test.py
+++ b/meltingpot/utils/scenarios/scenario_action_validation_test.py
@@ -15,6 +15,7 @@
 
 from unittest import mock
 
+from absl.testing import absltest
 from absl.testing import parameterized
 from meltingpot.utils.scenarios import scenario as scenario_utils
 
@@ -36,4 +37,4 @@ class ScenarioActionValidationTest(parameterized.TestCase):
 
 
 if __name__ == '__main__':
-  parameterized.absltest.main()
+  absltest.main()


### PR DESCRIPTION
## Summary

Validate the number of focal actions supplied to a scenario before publishing the action or waiting for background bot actions.

`Scenario._await_full_action` merges the caller-provided focal actions with background actions according to `is_focal`. With too many focal actions, the extra values were silently ignored by the merge. With too few, the failure surfaced later during iteration rather than at the scenario API boundary.

This change:
- requires exactly one action for each focal player slot
- raises a clear `ValueError` for too few or too many focal actions
- performs validation before emitting the focal action observable or waiting for background bots
- adds regression coverage for invalid focal action counts

## Testing

Added a focused regression test covering too few and too many focal actions and verifying validation happens before background-policy work.