### PR TITLE
Close saved model when puppet bot construction fails

### DIFF
--- a/meltingpot/bot.py
+++ b/meltingpot/bot.py
@@ -58,8 +58,13 @@ def build_from_config(config: bot_configs.BotConfig) -> policy.Policy:
   """
   saved_model = saved_model_policy.SavedModelPolicy(config.model_path)
   if config.puppeteer_builder:
-    puppeteer = config.puppeteer_builder()
-    return puppet_policy.PuppetPolicy(puppeteer=puppeteer, puppet=saved_model)
+    try:
+      puppeteer = config.puppeteer_builder()
+      return puppet_policy.PuppetPolicy(
+          puppeteer=puppeteer, puppet=saved_model)
+    except Exception:
+      saved_model.close()
+      raise
   else:
     return saved_model
 

--- a/meltingpot/bot_cleanup_test.py
+++ b/meltingpot/bot_cleanup_test.py
@@ -1,0 +1,42 @@
+# Copyright 2026 DeepMind Technologies Limited.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Regression test for bot construction cleanup."""
+
+from unittest import mock
+
+from absl.testing import absltest
+from meltingpot import bot
+
+
+class BotCleanupTest(absltest.TestCase):
+
+  def test_closes_saved_model_when_puppeteer_builder_fails(self):
+    config = mock.Mock()
+    config.model_path = 'model_path'
+    config.puppeteer_builder = mock.Mock(
+        side_effect=RuntimeError('puppeteer build failed'))
+    saved_model = mock.Mock()
+
+    with mock.patch.object(
+        bot.saved_model_policy,
+        'SavedModelPolicy',
+        return_value=saved_model):
+      with self.assertRaisesRegex(RuntimeError, 'puppeteer build failed'):
+        bot.build_from_config(config)
+
+    saved_model.close.assert_called_once_with()
+
+
+if __name__ == '__main__':
+  absltest.main()


### PR DESCRIPTION
## Summary

Close a saved-model policy if construction of its puppeteer wrapper fails.

`build_from_config` creates the `SavedModelPolicy` before invoking `config.puppeteer_builder`. If the puppeteer builder raises, the already-created saved model is currently abandoned without `close()` being called.

This change:
- wraps puppet-bot construction in failure cleanup
- closes the saved-model policy if the puppeteer builder or `PuppetPolicy` construction raises
- leaves ownership unchanged on successful construction
- adds a regression test for a failing puppeteer builder

## Testing

Added a focused unit test that verifies the saved model is closed when puppeteer construction raises.