### PR TITLE
Clean up scenario resources when construction fails

### DIFF
--- a/meltingpot/utils/scenarios/scenario_factory.py
+++ b/meltingpot/utils/scenarios/scenario_factory.py
@@ -14,6 +14,7 @@
 """Factory class for building scenarios."""
 
 from collections.abc import Collection, Mapping, Sequence
+import contextlib
 from typing import Callable, Optional
 
 import dm_env
@@ -85,19 +86,37 @@ class ScenarioFactory:
     """Returns spec of action expected from a single focal player."""
     return self._substrate.action_spec()
 
+  def _build_scenario(
+      self,
+      substrate: substrate_lib.Substrate,
+      permitted_observations: Collection[str],
+  ) -> scenario_lib.Scenario:
+    """Builds a scenario and cleans up owned resources if construction fails."""
+    with contextlib.ExitStack() as stack:
+      stack.callback(substrate.close)
+      bots = {}
+      for name, factory in self._bots.items():
+        bot = factory.build()
+        stack.callback(bot.close)
+        bots[name] = bot
+      scenario = scenario_lib.build_scenario(
+          substrate=substrate,
+          bots=bots,
+          bots_by_role=self._bots_by_role,
+          roles=self._roles,
+          is_focal=self._is_focal,
+          permitted_observations=permitted_observations)
+      stack.pop_all()
+      return scenario
+
   def build(self) -> scenario_lib.Scenario:
     """Builds the scenario.
 
     Returns:
       The constructed scenario.
     """
-    return scenario_lib.build_scenario(
-        substrate=self._substrate.build(self._roles),
-        bots={name: factory.build() for name, factory in self._bots.items()},
-        bots_by_role=self._bots_by_role,
-        roles=self._roles,
-        is_focal=self._is_focal,
-        permitted_observations=self._permitted_observations)
+    substrate = self._substrate.build(self._roles)
+    return self._build_scenario(substrate, self._permitted_observations)
 
   def build_transformed(
       self, substrate_transform: Optional[SubstrateTransform] = None
@@ -117,13 +136,11 @@ class ScenarioFactory:
       The constructed scenario.
     """
     substrate = self._substrate.build(self._roles)
-    if substrate_transform:
-      substrate = substrate_transform(substrate)
-    all_observations = frozenset().union(*substrate.observation_spec())
-    return scenario_lib.build_scenario(
-        substrate=substrate,
-        bots={name: factory.build() for name, factory in self._bots.items()},
-        bots_by_role=self._bots_by_role,
-        roles=self._roles,
-        is_focal=self._is_focal,
-        permitted_observations=all_observations)
+    try:
+      if substrate_transform:
+        substrate = substrate_transform(substrate)
+      all_observations = frozenset().union(*substrate.observation_spec())
+    except Exception:
+      substrate.close()
+      raise
+    return self._build_scenario(substrate, all_observations)

--- a/meltingpot/utils/scenarios/scenario_factory_cleanup_test.py
+++ b/meltingpot/utils/scenarios/scenario_factory_cleanup_test.py
@@ -1,0 +1,87 @@
+# Copyright 2026 DeepMind Technologies Limited.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Regression tests for ScenarioFactory failure cleanup."""
+
+from unittest import mock
+
+from absl.testing import absltest
+from meltingpot.utils.scenarios import scenario_factory
+
+
+class ScenarioFactoryCleanupTest(absltest.TestCase):
+
+  def _make_factory(self, substrate_factory, bots):
+    return scenario_factory.ScenarioFactory(
+        substrate=substrate_factory,
+        bots=bots,
+        bots_by_role={'role': tuple(bots)},
+        roles=('role',),
+        is_focal=(False,),
+        permitted_observations={'RGB'},
+    )
+
+  def test_build_closes_completed_resources_when_bot_build_fails(self):
+    substrate = mock.Mock()
+    substrate_factory = mock.Mock()
+    substrate_factory.build.return_value = substrate
+
+    built_bot = mock.Mock()
+    good_factory = mock.Mock()
+    good_factory.build.return_value = built_bot
+    bad_factory = mock.Mock()
+    bad_factory.build.side_effect = RuntimeError('bot build failed')
+    factory = self._make_factory(
+        substrate_factory, {'good': good_factory, 'bad': bad_factory})
+
+    with self.assertRaisesRegex(RuntimeError, 'bot build failed'):
+      factory.build()
+
+    built_bot.close.assert_called_once_with()
+    substrate.close.assert_called_once_with()
+
+  def test_build_closes_resources_when_scenario_construction_fails(self):
+    substrate = mock.Mock()
+    substrate_factory = mock.Mock()
+    substrate_factory.build.return_value = substrate
+
+    built_bot = mock.Mock()
+    bot_factory = mock.Mock()
+    bot_factory.build.return_value = built_bot
+    factory = self._make_factory(substrate_factory, {'bot': bot_factory})
+
+    with mock.patch.object(
+        scenario_factory.scenario_lib,
+        'build_scenario',
+        side_effect=RuntimeError('scenario build failed')):
+      with self.assertRaisesRegex(RuntimeError, 'scenario build failed'):
+        factory.build()
+
+    built_bot.close.assert_called_once_with()
+    substrate.close.assert_called_once_with()
+
+  def test_build_transformed_closes_substrate_when_transform_fails(self):
+    substrate = mock.Mock()
+    substrate_factory = mock.Mock()
+    substrate_factory.build.return_value = substrate
+    factory = self._make_factory(substrate_factory, {})
+
+    transform = mock.Mock(side_effect=RuntimeError('transform failed'))
+    with self.assertRaisesRegex(RuntimeError, 'transform failed'):
+      factory.build_transformed(transform)
+
+    substrate.close.assert_called_once_with()
+
+
+if __name__ == '__main__':
+  absltest.main()


### PR DESCRIPTION
## Summary

Ensure `ScenarioFactory` releases already-created substrates and bot policies if scenario construction fails partway through.

Previously, `build` created the substrate and bot policies inline in the `build_scenario` call. If a later bot factory or `build_scenario` itself raised, resources that had already been created were left open. `build_transformed` had the same issue when the substrate transform or transformed observation-spec lookup failed.

This change:
- centralizes scenario construction in a helper that owns resources until construction succeeds
- closes already-built bot policies and the substrate if a later construction step raises
- transfers ownership to the returned `Scenario` only after successful construction
- closes the substrate if a transform or transformed-spec lookup fails
- adds regression tests for bot-build failure, scenario-construction failure, and transform failure

## Testing

Added focused `ScenarioFactory` failure-cleanup tests using mock substrates and policies.