### PR TITLE
Handle standard FIRST timesteps without rewards

### DIFF
--- a/meltingpot/utils/evaluation/return_subject.py
+++ b/meltingpot/utils/evaluation/return_subject.py
@@ -22,6 +22,7 @@ class ReturnSubject(subject.Subject):
   """Subject that emits the player returns at the end of each episode."""
 
   _return: np.ndarray | None = None
+  _episode_started: bool = False
 
   def on_next(self, timestep: dm_env.TimeStep) -> None:
     """Called on each timestep.
@@ -30,10 +31,17 @@ class ReturnSubject(subject.Subject):
       timestep: the most recent timestep.
     """
     if timestep.step_type.first():
-      self._return = np.zeros_like(timestep.reward)
-    elif self._return is None:
+      self._return = None
+      self._episode_started = True
+    elif not self._episode_started:
       raise ValueError('First timestep must be StepType.FIRST.')
-    self._return += timestep.reward
+
+    if timestep.reward is not None:
+      if self._return is None:
+        self._return = np.zeros_like(timestep.reward)
+      self._return += timestep.reward
+
     if timestep.step_type.last():
       super().on_next(self._return)
       self._return = None
+      self._episode_started = False

--- a/meltingpot/utils/evaluation/return_subject_test.py
+++ b/meltingpot/utils/evaluation/return_subject_test.py
@@ -34,7 +34,7 @@ class ReturnSubjectTest(absltest.TestCase):
 
   def test(self):
     timesteps = [
-        dm_env.restart(observation=[{}])._replace(reward=[0, 0]),
+        dm_env.restart(observation=[{}]),
         dm_env.transition(observation=[{}], reward=[2, 4]),
         dm_env.termination(observation=[{}], reward=[1, 3]),
     ]


### PR DESCRIPTION
## Summary

Allow `ReturnSubject` to handle a standard `dm_env.restart(...)` timestep, whose reward is normally `None`.

The existing implementation initializes the accumulator with `np.zeros_like(timestep.reward)` and immediately adds `timestep.reward`. When the first timestep uses the normal dm_env semantics (`reward=None`), this raises a `TypeError` before the episode can be tracked.

This change:
- tracks episode start separately from whether a reward accumulator has been initialized
- initializes the return accumulator on the first non-`None` reward
- ignores the expected `None` reward on a FIRST timestep
- resets both pieces of state after the terminal timestep
- updates the existing unit test to use an unmodified `dm_env.restart(...)`

## Testing

Updated the focused `ReturnSubject` unit test so the episode begins with a standard FIRST timestep whose reward is `None`, while preserving the expected accumulated return.