### PR TITLE
Handle video writer initialization failures explicitly

### DIFF
--- a/meltingpot/utils/evaluation/video_subject.py
+++ b/meltingpot/utils/evaluation/video_subject.py
@@ -80,8 +80,14 @@ class VideoSubject(subject.Subject):
           isColor=True)
     elif self._writer is None:
       raise ValueError('First timestep must be StepType.FIRST.')
+
+    if not self._writer.isOpened():
+      self._writer.release()
+      self._writer = None
+      self._path = None
+      raise RuntimeError('Failed to open video writer.')
+
     bgr_frame = cv2.cvtColor(rgb_frame, cv2.COLOR_RGB2BGR)
-    assert self._writer.isOpened()  # Catches any cv2 usage errors.
     self._writer.write(bgr_frame)
     if timestep.step_type.last():
       self._writer.release()

--- a/meltingpot/utils/evaluation/video_subject_writer_test.py
+++ b/meltingpot/utils/evaluation/video_subject_writer_test.py
@@ -1,0 +1,47 @@
+# Copyright 2026 DeepMind Technologies Limited.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Regression tests for video writer initialization failures."""
+
+import tempfile
+from unittest import mock
+
+from absl.testing import absltest
+import dm_env
+from meltingpot.utils.evaluation import video_subject
+import numpy as np
+
+
+class VideoSubjectWriterTest(absltest.TestCase):
+
+  def test_failed_writer_open_raises_and_cleans_up(self):
+    writer = mock.Mock()
+    writer.isOpened.return_value = False
+    subject = video_subject.VideoSubject(tempfile.mkdtemp())
+    frame = np.zeros((8, 16, 3), dtype=np.uint8)
+    timestep = dm_env.restart(observation=[{'WORLD.RGB': frame}])
+
+    with mock.patch.object(
+        video_subject.cv2, 'VideoWriter', return_value=writer
+    ):
+      with self.assertRaisesRegex(RuntimeError, 'open video writer'):
+        subject.on_next(timestep)
+
+    writer.release.assert_called_once_with()
+    writer.write.assert_not_called()
+    self.assertIsNone(subject._writer)
+    self.assertIsNone(subject._path)
+
+
+if __name__ == '__main__':
+  absltest.main()


### PR DESCRIPTION
## Summary

Replace the runtime `assert` used to check OpenCV `VideoWriter` initialization with explicit error handling.

`VideoSubject` currently relies on `assert self._writer.isOpened()`. Assertions can be disabled with Python optimization, which would allow execution to continue and attempt to write through an unopened writer. A failed writer also remains stored on the subject.

This change:
- checks `VideoWriter.isOpened()` explicitly
- releases and clears a failed writer before raising
- raises a clear `RuntimeError` instead of relying on `assert`
- prevents frame writes after writer initialization failure
- adds focused regression coverage using a mocked failed writer

## Testing

Added a unit test verifying a failed `VideoWriter` is released, subject state is cleared, no frame is written, and a `RuntimeError` is raised.