### PR TITLE
Validate DMLab2D player indices in multiplayer wrapper

### DIFF
--- a/meltingpot/utils/substrates/wrappers/multiplayer_wrapper.py
+++ b/meltingpot/utils/substrates/wrappers/multiplayer_wrapper.py
@@ -72,10 +72,22 @@ class Wrapper(observables.ObservableLab2dWrapper):
     self._global_observation_names = set(global_observation_names)
 
   def _get_num_players(self) -> int:
-    """Returns maximum player index in dmlab2d action spec."""
+    """Returns the number of players in the dmlab2d action spec."""
     action_spec_keys = super().action_spec().keys()
-    lua_player_indices = (int(key.split(".", 1)[0]) for key in action_spec_keys)
-    return max(lua_player_indices)
+    lua_player_indices = [
+        int(key.split(".", 1)[0]) for key in action_spec_keys
+    ]
+    if not lua_player_indices:
+      raise ValueError(
+          "DMLab2D action spec must contain at least one player action.")
+    num_players = max(lua_player_indices)
+    actual_indices = set(lua_player_indices)
+    expected_indices = set(range(1, num_players + 1))
+    if actual_indices != expected_indices:
+      raise ValueError(
+          "DMLab2D action spec player indices must be contiguous and start "
+          f"at 1; found {sorted(actual_indices)}.")
+    return num_players
 
   def _get_observations(
       self, source: Mapping[str, T]) -> Sequence[Mapping[str, T]]:

--- a/meltingpot/utils/substrates/wrappers/multiplayer_wrapper_player_index_test.py
+++ b/meltingpot/utils/substrates/wrappers/multiplayer_wrapper_player_index_test.py
@@ -1,0 +1,59 @@
+# Copyright 2026 DeepMind Technologies Limited.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Regression tests for DMLab2D player index validation."""
+
+from unittest import mock
+
+from absl.testing import parameterized
+import dm_env
+import dmlab2d
+from meltingpot.utils.substrates.wrappers import multiplayer_wrapper
+import numpy as np
+
+
+ACT_SPEC = dm_env.specs.BoundedArray(
+    shape=(), minimum=0, maximum=4, dtype=np.int8)
+
+
+class MultiplayerPlayerIndexValidationTest(parameterized.TestCase):
+
+  @parameterized.named_parameters(
+      ('zero_based', {'0.MOVE': ACT_SPEC, '1.MOVE': ACT_SPEC}),
+      ('gapped', {'1.MOVE': ACT_SPEC, '3.MOVE': ACT_SPEC}),
+  )
+  def test_rejects_non_contiguous_player_indices(self, action_spec):
+    env = mock.Mock(spec_set=dmlab2d.Environment)
+    env.action_spec.return_value = action_spec
+
+    with self.assertRaisesRegex(ValueError, 'contiguous and start at 1'):
+      multiplayer_wrapper.Wrapper(
+          env,
+          individual_observation_names=[],
+          global_observation_names=[],
+      )
+
+  def test_rejects_empty_action_spec(self):
+    env = mock.Mock(spec_set=dmlab2d.Environment)
+    env.action_spec.return_value = {}
+
+    with self.assertRaisesRegex(ValueError, 'at least one player action'):
+      multiplayer_wrapper.Wrapper(
+          env,
+          individual_observation_names=[],
+          global_observation_names=[],
+      )
+
+
+if __name__ == '__main__':
+  parameterized.absltest.main()

--- a/meltingpot/utils/substrates/wrappers/multiplayer_wrapper_player_index_test.py
+++ b/meltingpot/utils/substrates/wrappers/multiplayer_wrapper_player_index_test.py
@@ -15,6 +15,7 @@
 
 from unittest import mock
 
+from absl.testing import absltest
 from absl.testing import parameterized
 import dm_env
 import dmlab2d
@@ -56,4 +57,4 @@ class MultiplayerPlayerIndexValidationTest(parameterized.TestCase):
 
 
 if __name__ == '__main__':
-  parameterized.absltest.main()
+  absltest.main()


### PR DESCRIPTION
## Summary

Validate the player indices encoded in the DMLab2D action spec before converting it to Melting Pot's multiplayer list representation.

The wrapper currently infers the player count with `max(...)`. This allows malformed specs such as players 1 and 3 with no player 2. Player index 0 is especially problematic because subtracting one later maps it to Python index `-1`.

This change:
- requires the action spec to contain at least one player action
- requires player indices to start at 1
- requires player indices to be contiguous
- raises a clear `ValueError` for malformed action specs
- adds regression coverage for empty, zero-based, and gapped player indices

## Testing

Added focused unit tests for invalid DMLab2D player-index layouts while preserving the existing valid three-player behavior.