### PR TITLE
Initialize all SavedModel tables before marking function initialized

### DIFF
--- a/meltingpot/utils/policies/permissive_model.py
+++ b/meltingpot/utils/policies/permissive_model.py
@@ -123,7 +123,8 @@ class PermissiveModel:
           shared_name=table_handle_name)
       tf.raw_ops.LookupTableImportV2(
           table_handle=table_handle, keys=table_keys, values=table_values)
-      self._initialized_tables[name] = self._tables.pop(name)  # Only init once.
+
+    self._initialized_tables[name] = self._tables.pop(name)  # Only init once.
 
   def _make_permissive_function(self, name: str) -> Callable[..., Any]:
     """Create a permissive version of a function in the SavedModel."""

--- a/meltingpot/utils/policies/permissive_model_test.py
+++ b/meltingpot/utils/policies/permissive_model_test.py
@@ -1,0 +1,71 @@
+# Copyright 2026 DeepMind Technologies Limited.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Tests for permissive SavedModel wrapping."""
+
+import types
+from unittest import mock
+
+from absl.testing import absltest
+from meltingpot.utils.policies import permissive_model
+
+
+class PermissiveModelTableTest(absltest.TestCase):
+
+  def test_initializes_all_tables_before_marking_function_initialized(self):
+    model = object.__new__(permissive_model.PermissiveModel)
+    keys_a = mock.Mock(dtype=mock.sentinel.key_dtype_a)
+    values_a = mock.Mock(dtype=mock.sentinel.value_dtype_a)
+    keys_b = mock.Mock(dtype=mock.sentinel.key_dtype_b)
+    values_b = mock.Mock(dtype=mock.sentinel.value_dtype_b)
+    tables = {
+        'table_a': (keys_a, values_a),
+        'table_b': (keys_b, values_b),
+    }
+    model._tables = {'step': tables}
+    model._initialized_tables = {}
+
+    nodes = [
+        types.SimpleNamespace(
+            name='table_a',
+            attr={'shared_name': types.SimpleNamespace(s=b'table-a')},
+        ),
+        types.SimpleNamespace(
+            name='table_b',
+            attr={'shared_name': types.SimpleNamespace(s=b'table-b')},
+        ),
+    ]
+    graph_def = types.SimpleNamespace(
+        node=nodes,
+        library=types.SimpleNamespace(function=[]),
+    )
+    concrete_func = mock.Mock()
+    concrete_func.graph.as_graph_def.return_value = graph_def
+
+    with mock.patch.object(
+        permissive_model.tf.raw_ops,
+        'HashTableV2',
+        side_effect=[mock.sentinel.handle_a, mock.sentinel.handle_b],
+    ) as hash_table, mock.patch.object(
+        permissive_model.tf.raw_ops, 'LookupTableImportV2'
+    ) as import_table:
+      model._maybe_init_tables(concrete_func, 'step')
+
+    self.assertEqual(hash_table.call_count, 2)
+    self.assertEqual(import_table.call_count, 2)
+    self.assertNotIn('step', model._tables)
+    self.assertIs(model._initialized_tables['step'], tables)
+
+
+if __name__ == '__main__':
+  absltest.main()


### PR DESCRIPTION
## Summary

Fix initialization of SavedModel functions that own more than one hash table.

`PermissiveModel._maybe_init_tables` previously moved the function entry from `_tables` to `_initialized_tables` inside the loop over that function's tables. The first table therefore removed the entry, and a second table could fail when the code attempted to remove the same function entry again.

This change:
- initializes every table for the function before updating the initialization bookkeeping
- preserves the existing one-time initialization behavior
- adds a focused regression test with two tables on one function

## Testing

Added a unit test that mocks TensorFlow table creation/import and verifies both tables are initialized before the function is marked initialized.