### PR TITLE
Close TF1 session when SavedModel initialization fails

### DIFF
--- a/meltingpot/utils/policies/saved_model_policy.py
+++ b/meltingpot/utils/policies/saved_model_policy.py
@@ -125,9 +125,13 @@ class TF1SavedModelPolicy(policy.Policy[tree.Structure[np.ndarray]]):
     self._graph = tf.compat.v1.Graph()
     self._session = tf.compat.v1.Session(graph=self._graph)
 
-    with self._build_context():
-      model = tf.compat.v1.saved_model.load_v2(model_path)
-      self._model = permissive_model.PermissiveModel(model)
+    try:
+      with self._build_context():
+        model = tf.compat.v1.saved_model.load_v2(model_path)
+        self._model = permissive_model.PermissiveModel(model)
+    except Exception:
+      self._session.close()
+      raise
 
     self._initial_state_outputs = None
     self._step_inputs = None

--- a/meltingpot/utils/policies/saved_model_policy_cleanup_test.py
+++ b/meltingpot/utils/policies/saved_model_policy_cleanup_test.py
@@ -1,0 +1,50 @@
+# Copyright 2026 DeepMind Technologies Limited.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Regression test for TF1 SavedModel initialization cleanup."""
+
+import contextlib
+from unittest import mock
+
+from absl.testing import absltest
+from meltingpot.utils.policies import saved_model_policy
+
+
+class TF1SavedModelPolicyCleanupTest(absltest.TestCase):
+
+  def test_closes_session_when_saved_model_loading_fails(self):
+    graph = mock.Mock()
+    session = mock.Mock()
+
+    with mock.patch.object(
+        saved_model_policy.tf.compat.v1, 'Graph', return_value=graph
+    ), mock.patch.object(
+        saved_model_policy.tf.compat.v1, 'Session', return_value=session
+    ) as session_factory, mock.patch.object(
+        saved_model_policy.TF1SavedModelPolicy,
+        '_build_context',
+        return_value=contextlib.nullcontext(),
+    ), mock.patch.object(
+        saved_model_policy.tf.compat.v1.saved_model,
+        'load_v2',
+        side_effect=RuntimeError('load failed'),
+    ):
+      with self.assertRaisesRegex(RuntimeError, 'load failed'):
+        saved_model_policy.TF1SavedModelPolicy('/invalid/model')
+
+    session_factory.assert_called_once_with(graph=graph)
+    session.close.assert_called_once_with()
+
+
+if __name__ == '__main__':
+  absltest.main()


### PR DESCRIPTION
## Summary

Close the TensorFlow session if `TF1SavedModelPolicy` construction fails after the session has been created.

The TF1 policy creates its graph and `Session` before loading and wrapping the SavedModel. If SavedModel loading or `PermissiveModel` construction raises, object construction aborts and the session is left open because no policy instance is returned to the caller.

This change:
- wraps SavedModel loading and permissive-model construction in failure cleanup
- closes the already-created TF1 session before re-raising initialization errors
- preserves existing ownership and `close()` behavior after successful construction
- adds focused regression coverage for a failing SavedModel load

## Testing

Added a unit test verifying the TF1 session is created with the expected graph and closed exactly once when SavedModel loading fails.