### PR TITLE
Clean up partially built substrates on construction failure

### DIFF
--- a/meltingpot/utils/substrates/substrate.py
+++ b/meltingpot/utils/substrates/substrate.py
@@ -14,6 +14,7 @@
 """Substrate builder."""
 
 from collections.abc import Collection, Mapping, Sequence
+import contextlib
 from typing import Any
 
 import chex
@@ -127,13 +128,18 @@ def build_substrate(
     The constructed substrate.
   """
   env = builder.builder(lab2d_settings)
-  env = observables_wrapper.ObservablesWrapper(env)
-  env = multiplayer_wrapper.Wrapper(
-      env,
-      individual_observation_names=individual_observations,
-      global_observation_names=global_observations)
-  env = discrete_action_wrapper.Wrapper(env, action_table=action_table)
-  # Add a wrapper that augments adds an observation of the collective
-  # reward (sum of all players' rewards).
-  env = collective_reward_wrapper.CollectiveRewardWrapper(env)
-  return Substrate(env)
+  try:
+    env = observables_wrapper.ObservablesWrapper(env)
+    env = multiplayer_wrapper.Wrapper(
+        env,
+        individual_observation_names=individual_observations,
+        global_observation_names=global_observations)
+    env = discrete_action_wrapper.Wrapper(env, action_table=action_table)
+    # Add a wrapper that augments adds an observation of the collective
+    # reward (sum of all players' rewards).
+    env = collective_reward_wrapper.CollectiveRewardWrapper(env)
+    return Substrate(env)
+  except Exception:
+    with contextlib.suppress(Exception):
+      env.close()
+    raise

--- a/meltingpot/utils/substrates/substrate_build_cleanup_test.py
+++ b/meltingpot/utils/substrates/substrate_build_cleanup_test.py
@@ -1,0 +1,67 @@
+# Copyright 2026 DeepMind Technologies Limited.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Regression tests for substrate construction cleanup."""
+
+from unittest import mock
+
+from absl.testing import absltest
+from meltingpot.utils.substrates import substrate
+
+
+class SubstrateBuildCleanupTest(absltest.TestCase):
+
+  def _build(self):
+    return substrate.build_substrate(
+        lab2d_settings=mock.sentinel.settings,
+        individual_observations=(),
+        global_observations=(),
+        action_table=(),
+    )
+
+  def test_closes_raw_environment_if_first_wrapper_fails(self):
+    raw_env = mock.Mock()
+    with mock.patch.object(
+        substrate.builder, 'builder', return_value=raw_env
+    ), mock.patch.object(
+        substrate.observables_wrapper,
+        'ObservablesWrapper',
+        side_effect=RuntimeError('wrapper failed'),
+    ):
+      with self.assertRaisesRegex(RuntimeError, 'wrapper failed'):
+        self._build()
+
+    raw_env.close.assert_called_once_with()
+
+  def test_closes_latest_owner_if_later_wrapper_fails(self):
+    raw_env = mock.Mock()
+    observable_env = mock.Mock()
+    with mock.patch.object(
+        substrate.builder, 'builder', return_value=raw_env
+    ), mock.patch.object(
+        substrate.observables_wrapper,
+        'ObservablesWrapper',
+        return_value=observable_env,
+    ), mock.patch.object(
+        substrate.multiplayer_wrapper,
+        'Wrapper',
+        side_effect=RuntimeError('multiplayer wrapper failed'),
+    ):
+      with self.assertRaisesRegex(RuntimeError, 'multiplayer wrapper failed'):
+        self._build()
+
+    observable_env.close.assert_called_once_with()
+
+
+if __name__ == '__main__':
+  absltest.main()


### PR DESCRIPTION
## Summary

Close the currently owned environment if `build_substrate` fails while assembling the wrapper stack.

`build_substrate` creates the underlying Lab2D environment and then transfers ownership through several wrappers. If any wrapper constructor raises, no substrate is returned to the caller and the most recently constructed environment is left without an owner that can close it.

This change:
- tracks the latest successfully constructed environment while wrappers are assembled
- closes that environment if a later construction step raises
- preserves the original construction exception even if cleanup itself fails
- leaves ownership unchanged after successful construction
- adds regression tests for failures in both the first and a later wrapper

## Testing

Added focused tests verifying cleanup of the raw environment when the first wrapper fails and cleanup of the latest wrapper owner when a later wrapper fails.