### PR TITLE
Validate substrate roles before building

### DIFF
--- a/meltingpot/utils/substrates/substrate_factory.py
+++ b/meltingpot/utils/substrates/substrate_factory.py
@@ -87,7 +87,15 @@ class SubstrateFactory:
 
     Returns:
       The constructed substrate.
+
+    Raises:
+      ValueError: if any requested role is not supported by the substrate.
     """
+    invalid_roles = set(roles) - self._valid_roles
+    if invalid_roles:
+      raise ValueError(
+          f'Invalid roles {sorted(invalid_roles)}; valid roles are '
+          f'{sorted(self._valid_roles)}.')
     return substrate.build_substrate(
         lab2d_settings=self._lab2d_settings_builder(roles),
         individual_observations=self._individual_observations,

--- a/meltingpot/utils/substrates/substrate_factory_test.py
+++ b/meltingpot/utils/substrates/substrate_factory_test.py
@@ -1,0 +1,61 @@
+# Copyright 2026 DeepMind Technologies Limited.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Tests for substrate factory role validation."""
+
+from unittest import mock
+
+from absl.testing import absltest
+from meltingpot.utils.substrates import substrate_factory
+
+
+class SubstrateFactoryRoleValidationTest(absltest.TestCase):
+
+  def _factory(self, settings_builder):
+    return substrate_factory.SubstrateFactory(
+        lab2d_settings_builder=settings_builder,
+        individual_observations=(),
+        global_observations=(),
+        action_table=(),
+        timestep_spec=mock.sentinel.timestep_spec,
+        action_spec=mock.sentinel.action_spec,
+        valid_roles={'red', 'blue'},
+        default_player_roles=('red',),
+    )
+
+  def test_rejects_invalid_role_before_building_settings(self):
+    settings_builder = mock.Mock()
+    factory = self._factory(settings_builder)
+
+    with self.assertRaisesRegex(ValueError, 'unknown'):
+      factory.build(('red', 'unknown'))
+
+    settings_builder.assert_not_called()
+
+  def test_valid_roles_are_forwarded_to_settings_builder(self):
+    settings_builder = mock.Mock(return_value=mock.sentinel.settings)
+    factory = self._factory(settings_builder)
+
+    with mock.patch.object(
+        substrate_factory.substrate,
+        'build_substrate',
+        return_value=mock.sentinel.substrate,
+    ):
+      result = factory.build(('blue', 'red'))
+
+    self.assertIs(result, mock.sentinel.substrate)
+    settings_builder.assert_called_once_with(('blue', 'red'))
+
+
+if __name__ == '__main__':
+  absltest.main()


### PR DESCRIPTION
## Summary

Validate requested player roles against `SubstrateFactory.valid_roles` before invoking the substrate-specific settings builder.

The public substrate API documents that every role passed to `build` must come from `valid_roles`, but `SubstrateFactory.build` currently forwards invalid values directly to each substrate's `lab2d_settings_builder`. This makes invalid input fail inconsistently, often as a downstream `KeyError` or other configuration-specific exception.

This change:
- rejects unsupported role names at the factory boundary
- reports both invalid and supported roles in a `ValueError`
- performs validation before constructing Lab2D settings
- preserves role order and existing behavior for valid assignments
- adds focused tests for invalid and valid role sequences

## Testing

Added unit coverage showing invalid roles are rejected before the settings builder runs and valid roles are forwarded unchanged.