### PR TITLE
Fix StateManager state validation in component_library.lua

### DIFF
--- a/.github/workflows/test-examples.yml
+++ b/.github/workflows/test-examples.yml
@@ -49,11 +49,7 @@ jobs:
         uses: ./.github/actions/install
 
       - name: Test examples
-        run: |
-          # pytest exits with code 5 when no tests are collected. Since the
-          # removal of examples/rllib and examples/gym there are no tests
-          # under examples/ anymore, so an empty run must not fail the check.
-          pytest examples || test $? -eq 5
+        run: pytest examples
 
       - name: Lint examples
         run: pylint --errors-only examples

--- a/.github/workflows/test-examples.yml
+++ b/.github/workflows/test-examples.yml
@@ -49,7 +49,11 @@ jobs:
         uses: ./.github/actions/install
 
       - name: Test examples
-        run: pytest examples
+        run: |
+          # pytest exits with code 5 when no tests are collected. Since the
+          # removal of examples/rllib and examples/gym there are no tests
+          # under examples/ anymore, so an empty run must not fail the check.
+          pytest examples || test $? -eq 5
 
       - name: Lint examples
         run: pylint --errors-only examples

--- a/meltingpot/lua/modules/component_library.lua
+++ b/meltingpot/lua/modules/component_library.lua
@@ -175,7 +175,7 @@ function StateManager:getInitialState()
 end
 
 function StateManager:_validateState(state)
-  assert(type(self._config.stateToConfigIndex[state]) ~= nil,
+  assert(self._config.stateToConfigIndex[state] ~= nil,
          'The state "' .. state .. '" is not available.')
 end
 
@@ -193,7 +193,7 @@ preregistered during initialization `allStateConfigs`.
 ]]
 function StateManager:setState(grid, state)
   local uState = self:getUniqueState(state)
-  self:_validateState(uState)
+  self:_validateState(state)
   grid:setState(self.gameObject:getPiece(), uState)
 end
 

--- a/meltingpot/utils/puppeteers/allelopathic_harvest_validation_test.py
+++ b/meltingpot/utils/puppeteers/allelopathic_harvest_validation_test.py
@@ -31,9 +31,9 @@ _PREFERENCES = (
 class ConventionFollowerValidationTest(parameterized.TestCase):
 
   @parameterized.parameters(
-      (),
-      _PREFERENCES[:2],
-      _PREFERENCES + (mock.sentinel.extra,),
+      ((),),
+      (_PREFERENCES[:2],),
+      (_PREFERENCES + (mock.sentinel.extra,),),
   )
   def test_requires_one_goal_per_rgb_channel(self, preference_goals):
     with self.assertRaisesRegex(ValueError, 'exactly 3 goals'):

--- a/meltingpot/utils/scenarios/scenario_action_validation_test.py
+++ b/meltingpot/utils/scenarios/scenario_action_validation_test.py
@@ -22,7 +22,7 @@ from meltingpot.utils.scenarios import scenario as scenario_utils
 
 class ScenarioActionValidationTest(parameterized.TestCase):
 
-  @parameterized.parameters([0], [1], [0, 1, 2])
+  @parameterized.parameters(([0],), ([1],), ([0, 1, 2],))
   def test_rejects_wrong_number_of_focal_actions(self, focal_action):
     scenario = object.__new__(scenario_utils.Scenario)
     scenario._is_focal = (True, False, True)

--- a/meltingpot/utils/substrates/wrappers/collective_reward_wrapper_reset_test.py
+++ b/meltingpot/utils/substrates/wrappers/collective_reward_wrapper_reset_test.py
@@ -27,7 +27,6 @@ class CollectiveRewardResetTest(absltest.TestCase):
     env = mock.Mock(spec_set=dmlab2d.Environment)
     env.reset.return_value = dm_env.restart(
         observation=[{'RGB': mock.sentinel.rgb}],
-        reward=[0.0],
     )
     wrapped = collective_reward_wrapper.CollectiveRewardWrapper(env)
 


### PR DESCRIPTION
## Problem

`StateManager:_validateState` in `meltingpot/lua/modules/component_library.lua` contained a no-op assertion:

```lua
assert(type(self._config.stateToConfigIndex[state]) ~= nil, ...)
```

In Lua, `type()` always returns a string (including the literal string `"nil"`), so `type(x) ~= nil` is always `true`. The validation that was meant to reject unregistered states therefore never fired. On top of this, `StateManager:setState` called `_validateState` with the uniquified state name (`uState`) rather than the raw state name, but `stateToConfigIndex` is keyed by the raw state names registered in the component's `stateConfigs`.

These two defects masked each other: because `_validateState` never asserted, the wrong argument passed by `setState` had no observable effect, and `setState` kept working by accident.

## Fix

- Check the index directly: `assert(self._config.stateToConfigIndex[state] ~= nil, ...)`.
- Validate the raw state name in `setState` (the same value `getGroupsForState` already passes to `_validateState`), keeping the uniquified name only for the actual `grid:setState` call.

## Result

Calling `setState` (or `getGroupsForState`) with a state name that was not registered now raises the intended, descriptive error ("The state \"...\" is not available.") instead of failing later with a cryptic engine error or silently proceeding. Existing valid state transitions are unaffected.