### PR TITLE
Validate custom human-player prefix count

### DIFF
--- a/meltingpot/human_players/level_playing_utils.py
+++ b/meltingpot/human_players/level_playing_utils.py
@@ -264,18 +264,16 @@ def run_episode(
       (Players are always switchable via the tab key.)
   """
   full_config.lab2d_settings.update(config_overrides)
+  player_count = full_config.lab2d_settings.get('numPlayers', 1)
   if player_prefixes is None:
-    player_count = full_config.lab2d_settings.get('numPlayers', 1)
     # By default, we use lua indices (which start at 1) as player prefixes.
     player_prefixes = [f'{i+1}' for i in range(player_count)]
-  else:
-    player_count = len(player_prefixes)
+  elif len(player_prefixes) != player_count:
+    raise ValueError('Player prefixes, when specified, must be of the same '
+                     'length as the number of players.')
   print(f'Running an episode with {player_count} players: {player_prefixes}.')
   with env_builder(**full_config) as env:
 
-    if len(player_prefixes) != player_count:
-      raise ValueError('Player prefixes, when specified, must be of the same '
-                       'length as the number of players.')
     player_index = initial_player_index
     timestep = env.reset()
 

--- a/meltingpot/human_players/level_playing_utils_test.py
+++ b/meltingpot/human_players/level_playing_utils_test.py
@@ -1,0 +1,48 @@
+# Copyright 2026 DeepMind Technologies Limited.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Tests for human-player level utilities."""
+
+from unittest import mock
+
+from absl.testing import absltest
+from meltingpot.human_players import level_playing_utils
+from ml_collections import config_dict
+
+
+class RunEpisodePlayerPrefixesTest(absltest.TestCase):
+
+  def test_rejects_prefix_count_mismatch_before_building_environment(self):
+    full_config = config_dict.ConfigDict({
+        'lab2d_settings': {
+            'numPlayers': 2,
+        },
+    })
+    env_builder = mock.Mock()
+
+    with self.assertRaisesRegex(ValueError, 'same length'):
+      level_playing_utils.run_episode(
+          render_observation='WORLD.RGB',
+          config_overrides={},
+          action_map={},
+          full_config=full_config,
+          interactive=level_playing_utils.RenderType.NONE,
+          env_builder=env_builder,
+          player_prefixes=('red',),
+      )
+
+    env_builder.assert_not_called()
+
+
+if __name__ == '__main__':
+  absltest.main()


### PR DESCRIPTION
## Summary

Validate custom `player_prefixes` against the configured number of players before building the environment.

When `player_prefixes` is provided, `run_episode` currently sets `player_count = len(player_prefixes)` and then checks whether `len(player_prefixes) != player_count`, which can never fail. A mismatched prefix list therefore bypasses the intended validation.

This change:
- derives `player_count` from `lab2d_settings.numPlayers`
- validates custom prefixes against that configured player count
- fails before environment construction when the lengths differ
- preserves the existing default prefix generation
- adds focused regression coverage

## Testing

Added a regression test with two configured players and one custom prefix, verifying that `ValueError` is raised before the environment builder is called.