### PR TITLE
Avoid requesting policy actions after terminal timesteps

### DIFF
--- a/meltingpot/utils/evaluation/evaluation.py
+++ b/meltingpot/utils/evaluation/evaluation.py
@@ -46,7 +46,8 @@ def run_episode(
   while not timestep.step_type.last():
     timestep = substrate.step(actions)
     population.send_timestep(timestep)
-    actions = population.await_action()
+    if not timestep.step_type.last():
+      actions = population.await_action()
 
 
 def run_and_observe_episodes(

--- a/meltingpot/utils/evaluation/evaluation_test.py
+++ b/meltingpot/utils/evaluation/evaluation_test.py
@@ -1,0 +1,47 @@
+# Copyright 2026 DeepMind Technologies Limited.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Tests for evaluation utilities."""
+
+from unittest import mock
+
+from absl.testing import absltest
+import dm_env
+from meltingpot.utils.evaluation import evaluation
+
+
+class RunEpisodeTest(absltest.TestCase):
+
+  def test_does_not_await_action_after_terminal_timestep(self):
+    population = mock.Mock()
+    substrate = mock.Mock()
+    first = dm_env.restart(observation=())
+    last = dm_env.termination(reward=0.0, observation=())
+    substrate.reset.return_value = first
+    substrate.step.return_value = last
+    population.await_action.return_value = mock.sentinel.action
+
+    evaluation.run_episode(population, substrate)
+
+    population.reset.assert_called_once_with()
+    substrate.reset.assert_called_once_with()
+    substrate.step.assert_called_once_with(mock.sentinel.action)
+    self.assertEqual(
+        population.send_timestep.call_args_list,
+        [mock.call(first), mock.call(last)],
+    )
+    population.await_action.assert_called_once_with()
+
+
+if __name__ == '__main__':
+  absltest.main()


### PR DESCRIPTION
## Summary

Avoid requesting another population action after the substrate has already returned a terminal timestep.

`evaluation.run_episode` currently sends the terminal timestep to the population and then unconditionally calls `await_action()`, even though that action can never be consumed because the episode is over.

This change:
- still forwards the terminal timestep to the population
- skips `await_action()` once the terminal timestep has been observed
- leaves action collection unchanged for non-terminal timesteps
- adds focused regression coverage

## Testing

Added a regression test for a one-step episode and verifies that `await_action()` is called only for the initial non-terminal timestep, while both the initial and terminal timesteps are still delivered to the population.