### PR TITLE
Fix SanctionerAlternator when nice is false

### DIFF
--- a/meltingpot/utils/puppeteers/clean_up.py
+++ b/meltingpot/utils/puppeteers/clean_up.py
@@ -347,11 +347,11 @@ class SanctionerAlternator(puppeteer.Puppeteer[SanctionerAlternatorState]):
     if prev_state.step_count < sanction_until:
       goal = self._sanction_goal
     else:
-      if ((prev_state.step_count // self._alternating_steps) % 2
-          ) == 0 and self._nice:
-        goal = self._cooperate_goal
-      else:
-        goal = self._defect_goal
+      even_phase = (
+          (prev_state.step_count // self._alternating_steps) % 2 == 0
+      )
+      cooperate = even_phase == self._nice
+      goal = self._cooperate_goal if cooperate else self._defect_goal
 
     return puppeteer.puppet_timestep(timestep, goal), SanctionerAlternatorState(
         sanction_until=sanction_until,

--- a/meltingpot/utils/puppeteers/clean_up_sanctioner_alternator_test.py
+++ b/meltingpot/utils/puppeteers/clean_up_sanctioner_alternator_test.py
@@ -3,9 +3,9 @@
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
-+#
+#
 #     https://www.apache.org/licenses/LICENSE-2.0
-+#
+#
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/meltingpot/utils/puppeteers/clean_up_sanctioner_alternator_test.py
+++ b/meltingpot/utils/puppeteers/clean_up_sanctioner_alternator_test.py
@@ -1,0 +1,54 @@
+# Copyright 2026 DeepMind Technologies Limited.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
++#
+#     https://www.apache.org/licenses/LICENSE-2.0
++#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Regression tests for SanctionerAlternator."""
+
+from unittest import mock
+
+from absl.testing import absltest
+from meltingpot.testing import puppeteers
+from meltingpot.utils.puppeteers import clean_up
+
+
+_COOPERATE = mock.sentinel.cooperate
+_DEFECT = mock.sentinel.defect
+_SANCTION = mock.sentinel.sanction
+_SIGNAL = 'NUM_OTHERS_WHO_CLEANED_THIS_STEP'
+
+
+class SanctionerAlternatorNotNiceTest(absltest.TestCase):
+
+  def test_not_nice_alternates_after_starting_with_defection(self):
+    puppeteer = clean_up.SanctionerAlternator(
+        cooperate_goal=_COOPERATE,
+        defect_goal=_DEFECT,
+        sanction_goal=_SANCTION,
+        num_others_cooperating_cumulant=_SIGNAL,
+        threshold=1,
+        recency_window=1,
+        steps_to_sanction_when_motivated=10,
+        alternating_steps=2,
+        nice=False,
+    )
+    observations = [{_SIGNAL: 1}] * 6
+
+    goals, _ = puppeteers.goals_from_observations(puppeteer, observations)
+
+    self.assertEqual(
+        goals,
+        [_DEFECT, _DEFECT, _COOPERATE, _COOPERATE, _DEFECT, _DEFECT],
+    )
+
+
+if __name__ == '__main__':
+  absltest.main()


### PR DESCRIPTION
## Summary

Fix `SanctionerAlternator` so `nice=False` still alternates between defection and cooperation after starting with defection.

The `nice` argument is documented as selecting whether the alternator starts with cooperation or defection. The current implementation applies `self._nice` only to the cooperative branch, so when `nice=False` both the even and odd phases select the defect goal. As a result, the policy never alternates.

This change:
- preserves the existing cooperate/defect schedule for `nice=True`
- makes `nice=False` start with defection and switch to cooperation on the next phase
- leaves sanctioning behavior unchanged
- adds focused regression coverage across multiple alternating phases

## Testing

Added a regression test with `alternating_steps=2` and `nice=False`, verifying the expected sequence: defect, defect, cooperate, cooperate, defect, defect.