### PR TITLE
Validate prefab map descriptors explicitly

### DIFF
--- a/meltingpot/utils/substrates/game_object_utils.py
+++ b/meltingpot/utils/substrates/game_object_utils.py
@@ -241,15 +241,20 @@ def get_game_objects_from_map(
     transforms = get_game_object_positions_from_map(ascii_map, char)
     for transform in transforms:
       if hasattr(prefab, "items"):
-        assert "type" in prefab
-        assert "list" in prefab
-        if prefab["type"] == TYPE_ALL:  # pyrefly: ignore[bad-index]
+        if "type" not in prefab or "list" not in prefab:
+          raise ValueError(
+              "Prefab descriptors must contain both 'type' and 'list'.")
+        descriptor_type = prefab["type"]
+        if descriptor_type == TYPE_ALL:  # pyrefly: ignore[bad-index]
           for p in prefab["list"]:  # pyrefly: ignore[bad-index]
             game_objects.append(_create_game_object(prefabs[p], transform))
-        elif prefab["type"] == TYPE_CHOICE:
+        elif descriptor_type == TYPE_CHOICE:
           game_objects.append(
               _create_game_object(prefabs[random.choice(prefab["list"])],  # pyrefly: ignore[bad-index]
                                   transform))
+        else:
+          raise ValueError(
+              f"Unknown prefab descriptor type: {descriptor_type!r}.")
       else:  # Typical case, since named prefab.
         game_objects.append(_create_game_object(prefabs[prefab], transform))
   return game_objects

--- a/meltingpot/utils/substrates/game_object_utils.py
+++ b/meltingpot/utils/substrates/game_object_utils.py
@@ -15,7 +15,7 @@
 
 import copy
 import enum
-from typing import List, Mapping, NamedTuple, Optional, Sequence, Tuple, Union
+from typing import Any, List, Mapping, NamedTuple, Optional, Sequence, Tuple, Union
 from meltingpot.utils.substrates import colors
 from meltingpot.utils.substrates import shapes
 import numpy as np
@@ -214,7 +214,7 @@ def _create_game_object(
 
 def get_game_objects_from_map(
     ascii_map: str,
-    char_prefab_map: Mapping[str, str],
+    char_prefab_map: Mapping[str, Union[str, Mapping[str, Any]]],
     prefabs: Mapping[str, PrefabConfig],
     random: np.random.RandomState = np.random.RandomState()
 ) -> List[PrefabConfig]:

--- a/meltingpot/utils/substrates/game_object_utils_descriptor_test.py
+++ b/meltingpot/utils/substrates/game_object_utils_descriptor_test.py
@@ -1,0 +1,53 @@
+# Copyright 2026 DeepMind Technologies Limited.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Tests for prefab map descriptor validation."""
+
+from absl.testing import absltest
+from absl.testing import parameterized
+from meltingpot.utils.substrates import game_object_utils
+
+
+_PREFABS = {
+    'item': {
+        'components': [
+            {
+                'component': 'Transform',
+                'kwargs': {},
+            },
+        ],
+    },
+}
+
+
+class PrefabMapDescriptorTest(parameterized.TestCase):
+
+  @parameterized.parameters(
+      {'type': game_object_utils.TYPE_ALL},
+      {'list': ['item']},
+  )
+  def test_rejects_incomplete_descriptor(self, descriptor):
+    with self.assertRaisesRegex(ValueError, "both 'type' and 'list'"):
+      game_object_utils.get_game_objects_from_map(
+          '\nA', {'A': descriptor}, _PREFABS)
+
+  def test_rejects_unknown_descriptor_type(self):
+    descriptor = {'type': 'unknown', 'list': ['item']}
+
+    with self.assertRaisesRegex(ValueError, 'Unknown prefab descriptor type'):
+      game_object_utils.get_game_objects_from_map(
+          '\nA', {'A': descriptor}, _PREFABS)
+
+
+if __name__ == '__main__':
+  absltest.main()

--- a/meltingpot/utils/substrates/game_object_utils_descriptor_test.py
+++ b/meltingpot/utils/substrates/game_object_utils_descriptor_test.py
@@ -33,8 +33,8 @@ _PREFABS = {
 class PrefabMapDescriptorTest(parameterized.TestCase):
 
   @parameterized.parameters(
-      {'type': game_object_utils.TYPE_ALL},
-      {'list': ['item']},
+      ({'type': game_object_utils.TYPE_ALL},),
+      ({'list': ['item']},),
   )
   def test_rejects_incomplete_descriptor(self, descriptor):
     with self.assertRaisesRegex(ValueError, "both 'type' and 'list'"):


### PR DESCRIPTION
## Summary

Validate structured prefab descriptors passed to `get_game_objects_from_map` with explicit errors.

Prefab descriptors currently rely on runtime `assert` statements for the required `type` and `list` fields. Assertions can be disabled with Python optimization. In addition, a descriptor with an unsupported `type` silently produces no game object at that map location, which makes configuration mistakes difficult to diagnose.

This change:
- raises `ValueError` when a prefab descriptor is missing `type` or `list`
- raises `ValueError` for unsupported descriptor types
- preserves existing `all` and `choice` descriptor behavior
- adds focused regression coverage for incomplete and unknown descriptors

## Testing

Added tests covering descriptors missing either required field and a descriptor using an unknown type.