### PR TITLE
Use HTTPS for Melting Pot asset downloads

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ from setuptools.command import build_py
 VERSION = '2.4.0'
 ASSETS_VERSION = '2.3.0'
 
-ASSETS_URL = f'http://storage.googleapis.com/dm-meltingpot/meltingpot-assets-{ASSETS_VERSION}.tar.gz'
+ASSETS_URL = f'https://storage.googleapis.com/dm-meltingpot/meltingpot-assets-{ASSETS_VERSION}.tar.gz'
 
 
 def _remove_excluded(description: str) -> str:


### PR DESCRIPTION
## Summary

Use HTTPS when downloading the Melting Pot asset archive from Google Cloud Storage.

`setup.py` currently uses an `http://storage.googleapis.com/...` URL for the archive that is downloaded and subsequently extracted during the build. Google Cloud Storage supports HTTPS at the same endpoint, so the archive can be fetched over an authenticated transport without changing the asset location or build behavior.

This change only updates the URL scheme from HTTP to HTTPS.

## Testing

URL-only change; the asset bucket, archive name, and download/extraction logic are unchanged.