### PR TITLE
Support populations with no roles

### DIFF
--- a/meltingpot/utils/scenarios/population.py
+++ b/meltingpot/utils/scenarios/population.py
@@ -87,9 +87,10 @@ class Population:
 
     self._locks = {name: threading.Lock() for name in self._policies}
     self._executor = concurrent.futures.ThreadPoolExecutor(
-        max_workers=len(roles))
+        max_workers=max(1, len(roles)))
     self._step_fns: List[Callable[[dm_env.TimeStep], int]] = []
     self._action_futures: List[concurrent.futures.Future[int]] = []
+    self._empty_action_pending = False
 
     self._names_subject = subject.Subject()
     self._action_subject = subject.Subject()
@@ -126,6 +127,7 @@ class Population:
     for future in self._action_futures:
       future.cancel()
     self._action_futures.clear()
+    self._empty_action_pending = False
 
   def send_timestep(self, timestep: dm_env.TimeStep) -> None:
     """Sends timestep to population for asynchronous processing.
@@ -136,9 +138,12 @@ class Population:
     Raises:
       RuntimeError: previous action has not been awaited.
     """
-    if self._action_futures:
+    if self._action_futures or self._empty_action_pending:
       raise RuntimeError('Previous action not retrieved.')
     self._timestep_subject.on_next(timestep)
+    if not self._step_fns:
+      self._empty_action_pending = True
+      return
     for n, step_fn in enumerate(self._step_fns):
       bot_timestep = timestep._replace(
           observation=timestep.observation[n], reward=timestep.reward[n])
@@ -154,6 +159,11 @@ class Population:
     Raises:
       RuntimeError: no timestep has been sent.
     """
+    if self._empty_action_pending:
+      self._empty_action_pending = False
+      actions = ()
+      self._action_subject.on_next(actions)
+      return actions
     if not self._action_futures:
       raise RuntimeError('No timestep sent.')
     actions = tuple(future.result() for future in self._action_futures)

--- a/meltingpot/utils/scenarios/population_empty_test.py
+++ b/meltingpot/utils/scenarios/population_empty_test.py
@@ -1,0 +1,63 @@
+# Copyright 2026 DeepMind Technologies Limited.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Tests for populations without background roles."""
+
+from absl.testing import absltest
+import dm_env
+from meltingpot.utils.scenarios import population as population_lib
+
+
+class EmptyPopulationTest(absltest.TestCase):
+
+  def setUp(self):
+    super().setUp()
+    self.population = population_lib.Population(
+        policies={}, names_by_role={}, roles=()
+    )
+    self.addCleanup(self.population.close)
+
+  def test_empty_population_round_trip(self):
+    actions = []
+    names = []
+    timesteps = []
+    observables = self.population.observables()
+    observables.action.subscribe(actions.append)
+    observables.names.subscribe(names.append)
+    observables.timestep.subscribe(timesteps.append)
+    timestep = dm_env.restart(observation=())
+
+    self.population.reset()
+    self.population.send_timestep(timestep)
+    action = self.population.await_action()
+
+    self.assertEmpty(action)
+    self.assertEqual(names, [[]])
+    self.assertEqual(actions, [()])
+    self.assertEqual(timesteps, [timestep])
+
+  def test_requires_empty_action_to_be_awaited(self):
+    self.population.reset()
+    timestep = dm_env.restart(observation=())
+    self.population.send_timestep(timestep)
+
+    with self.assertRaisesRegex(RuntimeError, 'Previous action'):
+      self.population.send_timestep(timestep)
+
+    self.assertEmpty(self.population.await_action())
+    with self.assertRaisesRegex(RuntimeError, 'No timestep'):
+      self.population.await_action()
+
+
+if __name__ == '__main__':
+  absltest.main()


### PR DESCRIPTION
## Summary

Allow `Population` to represent a zero-role population, which is needed when a scenario has no background players.

`Population` currently constructs `ThreadPoolExecutor(max_workers=len(roles))`. When `roles` is empty, construction fails immediately because `ThreadPoolExecutor` requires at least one worker. In addition, the existing `await_action()` logic treats an empty future list as if no timestep had been sent, so an empty population cannot complete the normal send/await cycle.

This change:
- allows construction when `roles` is empty
- records a pending empty action after a timestep is sent
- returns `()` from `await_action()` and publishes it through the action observable
- preserves the existing "previous action not retrieved" and "no timestep sent" checks
- leaves non-empty populations unchanged
- adds focused regression coverage

## Testing

Added tests for a zero-role population covering the normal reset/send/await round trip, observable emissions, and the existing action-retrieval state checks.