### PR TITLE
Reject empty resources in CoordinateWithPrevious

### DIFF
--- a/meltingpot/utils/puppeteers/coordination_in_the_matrix.py
+++ b/meltingpot/utils/puppeteers/coordination_in_the_matrix.py
@@ -38,9 +38,15 @@ class CoordinateWithPrevious(in_the_matrix.RespondToPrevious):
     """Initializes the puppeteer.
 
     Args:
-      resources: The collectible resources to coordinate on.
+      resources: The collectible resources to coordinate on. Must not be empty.
       margin: Try to collect `margin` more of the target resource than the other
         resource before interacting.
+
+    Raises:
+      ValueError: if `resources` is empty.
     """
+    resources = tuple(resources)
+    if not resources:
+      raise ValueError("resources must not be empty.")
     responses = {resource: resource for resource in resources}
     super().__init__(responses, margin)

--- a/meltingpot/utils/puppeteers/coordination_in_the_matrix_validation_test.py
+++ b/meltingpot/utils/puppeteers/coordination_in_the_matrix_validation_test.py
@@ -1,0 +1,30 @@
+# Copyright 2026 DeepMind Technologies Limited.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Validation tests for coordination puppeteers."""
+
+from absl.testing import absltest
+from meltingpot.utils.puppeteers import coordination_in_the_matrix
+
+
+class CoordinateWithPreviousValidationTest(absltest.TestCase):
+
+  def test_rejects_empty_resources_at_construction(self):
+    with self.assertRaisesRegex(ValueError, "resources must not be empty"):
+      coordination_in_the_matrix.CoordinateWithPrevious(
+          resources=(), margin=1
+      )
+
+
+if __name__ == '__main__':
+  absltest.main()


### PR DESCRIPTION
## Summary

Reject an empty resource collection when constructing `CoordinateWithPrevious`.

The current constructor builds an empty response mapping when `resources` is empty. Construction succeeds, but the first episode later calls `RespondToPrevious.initial_state()`, which reaches `random.choice([])` and fails with an opaque `IndexError`.

This change:
- materializes the supplied iterable once
- rejects an empty resource collection at construction time with a clear `ValueError`
- documents the non-empty requirement
- preserves existing behavior for valid resource collections
- adds focused regression coverage

## Testing

Added a regression test verifying that an empty resource collection is rejected immediately during construction.