### PR TITLE
Validate ConventionFollower configuration

### DIFF
--- a/meltingpot/utils/puppeteers/allelopathic_harvest.py
+++ b/meltingpot/utils/puppeteers/allelopathic_harvest.py
@@ -54,8 +54,13 @@ class ConventionFollower(puppeteer.Puppeteer[ConventionFollowerState]):
       color_threshold: threshold for a color to become dominant.
       recency_window: number of frames to check for a dominant color.
     """
+    if len(preference_goals) != 3:
+      raise ValueError('preference_goals must contain exactly 3 goals.')
+    if recency_window <= 0:
+      raise ValueError('recency_window must be positive.')
+
     self._initial_goal = initial_goal
-    self._preference_goals = preference_goals
+    self._preference_goals = tuple(preference_goals)
     self._color_threshold = color_threshold
     self._recency_window = recency_window
 

--- a/meltingpot/utils/puppeteers/allelopathic_harvest_validation_test.py
+++ b/meltingpot/utils/puppeteers/allelopathic_harvest_validation_test.py
@@ -1,0 +1,58 @@
+# Copyright 2026 DeepMind Technologies Limited.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Validation tests for allelopathic_harvest puppeteers."""
+
+from unittest import mock
+
+from absl.testing import absltest
+from absl.testing import parameterized
+from meltingpot.utils.puppeteers import allelopathic_harvest
+
+
+_INITIAL = mock.sentinel.initial
+_PREFERENCES = (
+    mock.sentinel.red,
+    mock.sentinel.green,
+    mock.sentinel.blue,
+)
+
+
+class ConventionFollowerValidationTest(parameterized.TestCase):
+
+  @parameterized.parameters(
+      (),
+      _PREFERENCES[:2],
+      _PREFERENCES + (mock.sentinel.extra,),
+  )
+  def test_requires_one_goal_per_rgb_channel(self, preference_goals):
+    with self.assertRaisesRegex(ValueError, 'exactly 3 goals'):
+      allelopathic_harvest.ConventionFollower(
+          initial_goal=_INITIAL,
+          preference_goals=preference_goals,
+          color_threshold=200,
+      )
+
+  @parameterized.parameters(0, -1)
+  def test_requires_positive_recency_window(self, recency_window):
+    with self.assertRaisesRegex(ValueError, 'recency_window must be positive'):
+      allelopathic_harvest.ConventionFollower(
+          initial_goal=_INITIAL,
+          preference_goals=_PREFERENCES,
+          color_threshold=200,
+          recency_window=recency_window,
+      )
+
+
+if __name__ == '__main__':
+  absltest.main()

--- a/meltingpot/utils/puppeteers/allelopathic_harvest_validation_test.py
+++ b/meltingpot/utils/puppeteers/allelopathic_harvest_validation_test.py
@@ -30,10 +30,10 @@ _PREFERENCES = (
 
 class ConventionFollowerValidationTest(parameterized.TestCase):
 
-  @parameterized.parameters(
-      (),
-      _PREFERENCES[:2],
-      _PREFERENCES + (mock.sentinel.extra,),
+  @parameterized.named_parameters(
+      ('empty', ()),
+      ('too_few', _PREFERENCES[:2]),
+      ('too_many', _PREFERENCES + (mock.sentinel.extra,)),
   )
   def test_requires_one_goal_per_rgb_channel(self, preference_goals):
     with self.assertRaisesRegex(ValueError, 'exactly 3 goals'):


### PR DESCRIPTION
## Summary

Validate `ConventionFollower` configuration at construction time.

`ConventionFollower` selects one of three preference goals from the dominant RGB channel, but the constructor currently accepts any number of `preference_goals`. Too few goals can therefore fail later during an episode with an `IndexError` only when the corresponding color becomes dominant. A non-positive `recency_window` is also accepted even though it does not represent a valid rolling observation window.

This change:
- requires exactly three preference goals, one for each RGB channel
- requires a positive `recency_window`
- stores the validated preference goals as an immutable tuple
- preserves existing behavior for valid configurations
- adds focused regression coverage

## Testing

Added parameterized tests covering missing, short, and oversized preference-goal sequences, plus zero and negative recency windows.