### PR TITLE
Return initial state for empty puppeteer sequences

### DIFF
--- a/meltingpot/testing/puppeteers.py
+++ b/meltingpot/testing/puppeteers.py
@@ -41,6 +41,8 @@ def goals_from_timesteps(
     state: Optional[State] = None,
 ) -> tuple[Sequence[puppeteer_lib.PuppetGoal], State]:
   """Returns puppet goals for each timestep."""
+  if state is None:
+    state = puppeteer.initial_state()
   goals = []
   for timestep, state in step_many(puppeteer, timesteps, state):
     goals.append(timestep.observation[GOAL_KEY])

--- a/meltingpot/testing/puppeteers_empty_test.py
+++ b/meltingpot/testing/puppeteers_empty_test.py
@@ -1,0 +1,35 @@
+# Copyright 2026 DeepMind Technologies Limited.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Regression tests for puppeteer test utilities."""
+
+from unittest import mock
+
+from absl.testing import absltest
+from meltingpot.testing import puppeteers
+from meltingpot.utils.puppeteers import fixed_goal
+
+
+class EmptyPuppeteerSequenceTest(absltest.TestCase):
+
+  def test_empty_sequence_returns_initial_state(self):
+    puppet = fixed_goal.FixedGoal(mock.sentinel.goal)
+
+    goals, state = puppeteers.goals_from_timesteps(puppet, ())
+
+    self.assertEmpty(goals)
+    self.assertEqual(state, puppet.initial_state())
+
+
+if __name__ == '__main__':
+  absltest.main()


### PR DESCRIPTION
## Summary

Make `goals_from_timesteps` return the puppeteer's initial state when the input timestep iterable is empty.

`step_many` initializes the puppeteer state internally, but when `goals_from_timesteps` receives an empty iterable its loop never executes, so the outer `state` remains `None`. The helper therefore returns `((), None)` instead of the initialized state even though the same helper returns the evolved puppeteer state for non-empty inputs.

This change:
- initializes the state in `goals_from_timesteps` when none is supplied
- passes that state through `step_many`
- preserves the existing behavior for non-empty timestep sequences and explicit caller-provided states
- adds focused regression coverage for an empty sequence

## Testing

Added a regression test using `FixedGoal` and an empty timestep sequence, verifying that the result contains no goals and returns the puppeteer's initial state.