### PR TITLE
Forward reset arguments through ResetWrapper

### DIFF
--- a/meltingpot/utils/substrates/wrappers/reset_wrapper.py
+++ b/meltingpot/utils/substrates/wrappers/reset_wrapper.py
@@ -34,7 +34,7 @@ class ResetWrapper(base.Lab2dWrapper):
     self._rebuild_environment = build_environment
     self._reset = False
 
-  def reset(self) -> dm_env.TimeStep:
+  def reset(self, *args, **kwargs) -> dm_env.TimeStep:
     """Rebuilds the environment and calls reset on it."""
     if self._reset:
       self._env.close()
@@ -42,4 +42,4 @@ class ResetWrapper(base.Lab2dWrapper):
     else:
       # Don't rebuild on very first reset call (it's inefficient).
       self._reset = True
-    return super().reset()
+    return super().reset(*args, **kwargs)

--- a/meltingpot/utils/substrates/wrappers/reset_wrapper_test.py
+++ b/meltingpot/utils/substrates/wrappers/reset_wrapper_test.py
@@ -1,0 +1,48 @@
+# Copyright 2026 DeepMind Technologies Limited.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Tests for ResetWrapper."""
+
+from unittest import mock
+
+from absl.testing import absltest
+import dmlab2d
+from meltingpot.utils.substrates.wrappers import reset_wrapper
+
+
+class ResetWrapperTest(absltest.TestCase):
+
+  def test_forwards_reset_arguments_before_and_after_rebuild(self):
+    first_env = mock.Mock(spec_set=dmlab2d.Environment)
+    second_env = mock.Mock(spec_set=dmlab2d.Environment)
+    build_environment = mock.Mock(side_effect=(first_env, second_env))
+    wrapped = reset_wrapper.ResetWrapper(build_environment)
+
+    first_arg = mock.sentinel.first_arg
+    first_kwarg = mock.sentinel.first_kwarg
+    wrapped.reset(first_arg, option=first_kwarg)
+
+    first_env.reset.assert_called_once_with(first_arg, option=first_kwarg)
+    first_env.close.assert_not_called()
+
+    second_arg = mock.sentinel.second_arg
+    second_kwarg = mock.sentinel.second_kwarg
+    wrapped.reset(second_arg, option=second_kwarg)
+
+    first_env.close.assert_called_once_with()
+    second_env.reset.assert_called_once_with(second_arg, option=second_kwarg)
+    self.assertEqual(build_environment.call_count, 2)
+
+
+if __name__ == '__main__':
+  absltest.main()


### PR DESCRIPTION
## Summary

Forward positional and keyword arguments received by `ResetWrapper.reset` to the currently wrapped environment.

`Lab2dWrapper.reset` already forwards `*args` and `**kwargs`, but `ResetWrapper` overrides `reset()` without accepting or forwarding them. This breaks normal wrapper passthrough semantics for reset calls that carry arguments, both before and after the environment is rebuilt.

This change:
- accepts `*args` and `**kwargs` in `ResetWrapper.reset`
- forwards them to the active underlying environment
- preserves the existing first-reset optimization
- preserves the environment rebuild behavior on subsequent resets
- adds focused regression coverage across both paths

## Testing

Added a test verifying distinct positional and keyword reset arguments reach the original environment on the first reset and the rebuilt environment on the next reset.