### PR TITLE
Report expected observation keys in substrate test failures

### DIFF
--- a/meltingpot/testing/substrates.py
+++ b/meltingpot/testing/substrates.py
@@ -60,7 +60,7 @@ class SubstrateTestCase(parameterized.TestCase):
         zip(observations, observation_specs)):
       if set(spec) != set(observation):
         self.fail(f'Observation {n} keys {set(observation)!r} do not match '
-                  f'spec keys {set(observation)!r}.')
+                  f'spec keys {set(spec)!r}.')
       for key in spec:
         try:
           spec[key].validate(observation[key])

--- a/meltingpot/testing/substrates_diagnostics_test.py
+++ b/meltingpot/testing/substrates_diagnostics_test.py
@@ -1,0 +1,47 @@
+# Copyright 2026 DeepMind Technologies Limited.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Regression tests for substrate test diagnostics."""
+
+from unittest import mock
+
+from absl.testing import absltest
+import dm_env
+from meltingpot.testing import substrates
+import numpy as np
+
+
+class SubstrateDiagnosticsTest(substrates.SubstrateTestCase):
+
+  def test_observation_key_mismatch_reports_spec_keys(self):
+    env = mock.Mock()
+    env.action_spec.return_value = (dm_env.specs.DiscreteArray(num_values=1),)
+    env.discount_spec.return_value = dm_env.specs.BoundedArray(
+        shape=(), dtype=np.float64, minimum=0.0, maximum=1.0)
+    env.reward_spec.return_value = (
+        dm_env.specs.Array(shape=(), dtype=np.float64),)
+    env.observation_spec.return_value = ({
+        'expected': dm_env.specs.Array(shape=(), dtype=np.float64),
+    },)
+    env.step.return_value = dm_env.transition(
+        reward=(0.0,), observation=({'actual': np.array(0.0)},))
+
+    with self.assertRaisesRegex(
+        AssertionError,
+        r"Observation 0 keys \{'actual'\} do not match spec keys \{'expected'\}",
+    ):
+      self.assert_step_matches_specs(env)
+
+
+if __name__ == '__main__':
+  absltest.main()


### PR DESCRIPTION
## Summary

Fix `SubstrateTestCase.assert_step_matches_specs` so observation-key mismatch errors report the expected spec keys.

The current failure message prints `set(observation)` for both the observed and expected key sets. When the keys differ, the diagnostic therefore shows the same set twice and hides the actual expected keys.

This change:
- reports `set(spec)` for the expected keys
- leaves the validation behavior unchanged
- adds focused regression coverage for the failure message

## Testing

Added a regression test with different observed and expected observation keys and verified that the resulting AssertionError reports both sets correctly.