### PR TITLE
Preserve boundary spaces when sizing WORLD.RGB

### DIFF
--- a/meltingpot/utils/substrates/specs.py
+++ b/meltingpot/utils/substrates/specs.py
@@ -117,9 +117,10 @@ def world_rgb(ascii_map: str,
     sprite_size: the width of the observation.
     name: optional name for the spec.
   """
-  lines = ascii_map.strip().split('\n')
+  map_body = ascii_map.strip('\n')
+  lines = map_body.split('\n') if map_body else []
   height = len(lines) * sprite_size
-  width = len(lines[0]) * sprite_size if height else 0
+  width = len(lines[0]) * sprite_size if lines else 0
   return rgb(height, width, name)
 
 

--- a/meltingpot/utils/substrates/specs.py
+++ b/meltingpot/utils/substrates/specs.py
@@ -117,10 +117,9 @@ def world_rgb(ascii_map: str,
     sprite_size: the width of the observation.
     name: optional name for the spec.
   """
-  map_body = ascii_map.strip('\n')
-  lines = map_body.split('\n') if map_body else []
+  lines = ascii_map.strip('\n').split('\n')
   height = len(lines) * sprite_size
-  width = len(lines[0]) * sprite_size if lines else 0
+  width = len(lines[0]) * sprite_size if height else 0
   return rgb(height, width, name)
 
 

--- a/meltingpot/utils/substrates/specs_world_rgb_test.py
+++ b/meltingpot/utils/substrates/specs_world_rgb_test.py
@@ -1,0 +1,31 @@
+# Copyright 2026 DeepMind Technologies Limited.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Regression tests for WORLD.RGB spec sizing."""
+
+from absl.testing import absltest
+from meltingpot.utils.substrates import specs
+
+
+class WorldRgbTest(absltest.TestCase):
+
+  def test_preserves_spaces_on_boundary_rows(self):
+    ascii_map = '\n  A\n BB\n'
+
+    actual = specs.world_rgb(ascii_map, sprite_size=8)
+
+    self.assertEqual(actual.shape, (16, 24, 3))
+
+
+if __name__ == '__main__':
+  absltest.main()


### PR DESCRIPTION
## Summary

Preserve meaningful spaces in ASCII maps when deriving `WORLD.RGB` dimensions.

`world_rgb` currently calls `ascii_map.strip()` before splitting the map into rows. Because `strip()` removes spaces as well as newlines, leading spaces on the first map row can be discarded before the row width is calculated, producing an incorrect WORLD.RGB spec.

This change:
- strips only leading and trailing newline characters
- preserves spaces that represent map cells
- retains the existing handling of triple-quoted maps with outer newlines
- adds focused regression coverage

## Testing

Added a map whose first row begins with two spaces and verified that, with an 8-pixel sprite size, the WORLD.RGB shape is `(16, 24, 3)`.