### PR TITLE
Reject duplicate resource indices in CounterPrevious

### DIFF
--- a/meltingpot/utils/puppeteers/running_with_scissors_in_the_matrix.py
+++ b/meltingpot/utils/puppeteers/running_with_scissors_in_the_matrix.py
@@ -45,6 +45,11 @@ class CounterPrevious(in_the_matrix.RespondToPrevious):
       margin: Try to collect `margin` more of the target resource than the other
         resource before interacting.
     """
+    resources = (rock_resource, paper_resource, scissors_resource)
+    if len({resource.index for resource in resources}) != len(resources):
+      raise ValueError(
+          'rock, paper, and scissors resources must have distinct indices.')
+
     responses = {
         rock_resource: paper_resource,
         paper_resource: scissors_resource,

--- a/meltingpot/utils/puppeteers/running_with_scissors_validation_test.py
+++ b/meltingpot/utils/puppeteers/running_with_scissors_validation_test.py
@@ -1,0 +1,44 @@
+# Copyright 2026 DeepMind Technologies Limited.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Validation tests for running-with-scissors puppeteers."""
+
+from unittest import mock
+
+from absl.testing import absltest
+from meltingpot.utils.puppeteers import in_the_matrix
+from meltingpot.utils.puppeteers import running_with_scissors_in_the_matrix
+
+
+def _resource(index):
+  return in_the_matrix.Resource(
+      index=index,
+      collect_goal=mock.sentinel.collect,
+      interact_goal=mock.sentinel.interact,
+  )
+
+
+class CounterPreviousValidationTest(absltest.TestCase):
+
+  def test_rejects_duplicate_resource_indices(self):
+    with self.assertRaisesRegex(ValueError, 'must have distinct indices'):
+      running_with_scissors_in_the_matrix.CounterPrevious(
+          rock_resource=_resource(0),
+          paper_resource=_resource(0),
+          scissors_resource=_resource(2),
+          margin=1,
+      )
+
+
+if __name__ == '__main__':
+  absltest.main()


### PR DESCRIPTION
## Summary

Validate that the rock, paper, and scissors resources used by `CounterPrevious` have distinct indices.

`RespondToPrevious` stores responses keyed by resource index. If two of the three strategy resources passed to `CounterPrevious` share an index, one response silently overwrites another when that mapping is constructed. The resulting bot can therefore implement the wrong counter-strategy without reporting the invalid configuration.

This change:
- requires rock, paper, and scissors to use distinct resource indices
- fails immediately with a clear `ValueError` when the configuration is ambiguous
- leaves valid counter-strategy behavior unchanged
- adds focused regression coverage

## Testing

Added a regression test with duplicate rock and paper indices and verified that construction fails with a clear error.