### PR TITLE
Forward reset arguments through ObservablesWrapper

### DIFF
--- a/meltingpot/utils/substrates/wrappers/observables_wrapper.py
+++ b/meltingpot/utils/substrates/wrappers/observables_wrapper.py
@@ -43,9 +43,9 @@ class ObservablesWrapper(observables_lib.ObservableLab2dWrapper):
         timestep=self._timestep_subject,
     )
 
-  def reset(self) -> dm_env.TimeStep:
+  def reset(self, *args, **kwargs) -> dm_env.TimeStep:
     """See base class."""
-    timestep = super().reset()
+    timestep = super().reset(*args, **kwargs)
     self._timestep_subject.on_next(timestep)
     for event in super().events():
       self._events_subject.on_next(event)

--- a/meltingpot/utils/substrates/wrappers/observables_wrapper_reset_test.py
+++ b/meltingpot/utils/substrates/wrappers/observables_wrapper_reset_test.py
@@ -1,0 +1,45 @@
+# Copyright 2026 DeepMind Technologies Limited.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Regression tests for ObservablesWrapper reset behavior."""
+
+from unittest import mock
+
+from absl.testing import absltest
+import dmlab2d
+from meltingpot.utils.substrates.wrappers import observables_wrapper
+
+
+class ObservablesWrapperResetTest(absltest.TestCase):
+
+  def test_forwards_reset_arguments_and_emits_timestep(self):
+    env = mock.Mock(spec_set=dmlab2d.Environment)
+    timestep = mock.sentinel.timestep
+    env.reset.return_value = timestep
+    env.events.return_value = ()
+    wrapped = observables_wrapper.ObservablesWrapper(env)
+    observed = []
+    subscription = wrapped.observables().timestep.subscribe(observed.append)
+    self.addCleanup(subscription.dispose)
+
+    reset_arg = mock.sentinel.reset_arg
+    reset_option = mock.sentinel.reset_option
+    actual = wrapped.reset(reset_arg, option=reset_option)
+
+    env.reset.assert_called_once_with(reset_arg, option=reset_option)
+    self.assertIs(actual, timestep)
+    self.assertEqual(observed, [timestep])
+
+
+if __name__ == '__main__':
+  absltest.main()


### PR DESCRIPTION
## Summary

Forward reset arguments through `ObservablesWrapper`.

`Lab2dWrapper.reset` accepts and forwards `*args` and `**kwargs`, but `ObservablesWrapper` overrides the method with a zero-argument signature and calls `super().reset()` without forwarding anything. This prevents reset options supported by the underlying environment from passing through the observable wrapper.

This change:
- accepts positional and keyword reset arguments
- forwards them to the wrapped environment
- preserves timestep and event observable behavior
- adds focused regression coverage

## Testing

Added a test that passes distinct positional and keyword reset arguments through the wrapper and verifies the returned timestep is still emitted by the timestep observable.