### PR TITLE
Keep procedural Coins maps rectangular

### DIFF
--- a/meltingpot/configs/substrates/coins.py
+++ b/meltingpot/configs/substrates/coins.py
@@ -75,7 +75,7 @@ def get_ascii_map(
 
   # Pad with extra rows to reach max height.
   for _ in range(max_height - height):
-    ascii_map += ["\n"] + [" "] * max_width
+    ascii_map += ["\n"] + [" "] * (max_width + 2)
 
   # Join list of strings into single string.
   ascii_map = "".join(ascii_map)

--- a/meltingpot/configs/substrates/coins_map_test.py
+++ b/meltingpot/configs/substrates/coins_map_test.py
@@ -1,0 +1,36 @@
+# Copyright 2026 DeepMind Technologies Limited.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Regression tests for the procedural Coins map."""
+
+from absl.testing import absltest
+from meltingpot.configs.substrates import coins
+
+
+class CoinsMapTest(absltest.TestCase):
+
+  def test_height_padding_preserves_row_width(self):
+    ascii_map = coins.get_ascii_map(
+        min_width=10,
+        max_width=10,
+        min_height=8,
+        max_height=10,
+    )
+
+    rows = ascii_map.splitlines()
+    self.assertLen(rows, 12)
+    self.assertEqual({len(row) for row in rows}, {12})
+
+
+if __name__ == '__main__':
+  absltest.main()


### PR DESCRIPTION
## Summary

Keep all rows produced by the procedural Coins map generator at the same width.

Normal rows in `get_ascii_map` are `max_width + 2` cells wide because they include the two boundary-wall columns. However, rows added when the sampled height is below `max_height` are currently padded with only `max_width` spaces. This produces ragged ASCII maps whenever `height < max_height`.

This change:
- pads extra rows to `max_width + 2`
- leaves the random width/height selection and spawn placement unchanged
- adds deterministic regression coverage for a map that requires height padding

## Testing

Added a test with a fixed width and `min_height < max_height`, verifying every generated row has the expected `max_width + 2` width.