### PR TITLE
Fix Harvest tutorial direct execution and verbose mode

### DIFF
--- a/examples/tutorial/harvest/play_harvest.py
+++ b/examples/tutorial/harvest/play_harvest.py
@@ -19,7 +19,10 @@ from absl import app
 from absl import flags
 from meltingpot.human_players import level_playing_utils
 
-from .configs.environment import harvest as game
+if __package__:
+  from .configs.environment import harvest as game
+else:
+  from configs.environment import harvest as game
 
 FLAGS = flags.FLAGS
 
@@ -42,7 +45,11 @@ _ACTION_MAP = {
 }
 
 
-def verbose_fn(unused_timestep, unused_player_index: int) -> None:
+def verbose_fn(
+    unused_timestep,
+    unused_player_index: int,
+    unused_current_player_index: int,
+) -> None:
   pass
 
 

--- a/examples/tutorial/harvest/play_harvest.py
+++ b/examples/tutorial/harvest/play_harvest.py
@@ -15,14 +15,19 @@
 
 Use `WASD` keys to move the character around. `Q` and `E` to turn.
 """
+import pathlib
+import sys
+
 from absl import app
 from absl import flags
 from meltingpot.human_players import level_playing_utils
 
-if __package__:
-  from .configs.environment import harvest as game
-else:
-  from configs.environment import harvest as game
+# Allow the documented `python examples/.../play_harvest.py` invocation while
+# retaining a normal absolute package import.
+_REPO_ROOT = str(pathlib.Path(__file__).resolve().parents[3])
+if _REPO_ROOT not in sys.path:
+  sys.path.insert(0, _REPO_ROOT)
+from examples.tutorial.harvest.configs.environment import harvest as game
 
 FLAGS = flags.FLAGS
 

--- a/examples/tutorial/harvest/play_harvest_test.py
+++ b/examples/tutorial/harvest/play_harvest_test.py
@@ -1,0 +1,37 @@
+# Copyright 2026 DeepMind Technologies Limited.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Regression tests for the Harvest tutorial player."""
+
+import pathlib
+import runpy
+import sys
+from unittest import mock
+
+from absl.testing import absltest
+
+
+class PlayHarvestTest(absltest.TestCase):
+
+  def test_standalone_import_and_verbose_callback(self):
+    script = pathlib.Path(__file__).with_name('play_harvest.py')
+    script_dir = str(script.parent)
+
+    with mock.patch.object(sys, 'path', [script_dir, *sys.path]):
+      namespace = runpy.run_path(str(script), run_name='harvest_tutorial_test')
+
+    namespace['verbose_fn'](None, 0, 0)
+
+
+if __name__ == '__main__':
+  absltest.main()


### PR DESCRIPTION
## Summary

Fix two execution paths in the Harvest substrate tutorial.

The tutorial documents running `python examples/tutorial/harvest/play_harvest.py`, but the script currently uses a package-relative import. When executed directly, Python has no package context and the import fails before the tutorial starts.

The script's `verbose_fn` also accepts two arguments, while `level_playing_utils.run_episode` calls verbose callbacks with three arguments, so `--verbose` raises `TypeError`.

This change:
- makes the documented direct script invocation resolve the tutorial package reliably
- updates the verbose callback signature to match `run_episode`
- preserves normal package imports
- adds focused regression coverage for standalone loading and the three-argument callback

## Testing

Added a regression test that loads `play_harvest.py` without package context and invokes `verbose_fn` with the same three-argument shape used by `run_episode`.