### PR TITLE
Avoid duplicate opening tremble in TitForTat

### DIFF
--- a/meltingpot/utils/puppeteers/in_the_matrix.py
+++ b/meltingpot/utils/puppeteers/in_the_matrix.py
@@ -405,14 +405,13 @@ class TitForTat(puppeteer.Puppeteer[bool]):
 
   def initial_state(self) -> bool:
     """See base class."""
-    is_cooperative = True if not tremble(self._tremble_probability) else False
-    return is_cooperative
+    return True
 
   def step(self, timestep: dm_env.TimeStep,
            prev_state: bool) -> tuple[dm_env.TimeStep, bool]:
     """See base class."""
     if timestep.first():
-      prev_state = self.initial_state()
+      prev_state = not tremble(self._tremble_probability)
 
     partner_resource = partner_max_resource(timestep)
     partner_defected = partner_resource == self._defect_resource.index

--- a/meltingpot/utils/puppeteers/in_the_matrix_initial_state_test.py
+++ b/meltingpot/utils/puppeteers/in_the_matrix_initial_state_test.py
@@ -1,0 +1,68 @@
+# Copyright 2026 DeepMind Technologies Limited.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Regression tests for matrix puppeteer initial state behavior."""
+
+from unittest import mock
+
+from absl.testing import absltest
+import dm_env
+from meltingpot.utils.puppeteers import in_the_matrix
+import numpy as np
+
+
+_COOPERATE = in_the_matrix.Resource(
+    index=1,
+    collect_goal=mock.sentinel.cooperate_collect,
+    interact_goal=mock.sentinel.cooperate_interact,
+)
+_DEFECT = in_the_matrix.Resource(
+    index=0,
+    collect_goal=mock.sentinel.defect_collect,
+    interact_goal=mock.sentinel.defect_interact,
+)
+
+
+class TitForTatInitialStateTest(absltest.TestCase):
+
+  def setUp(self):
+    super().setUp()
+    self.puppeteer = in_the_matrix.TitForTat(
+        cooperate_resource=_COOPERATE,
+        defect_resource=_DEFECT,
+        margin=1,
+        tremble_probability=0.5,
+    )
+
+  @mock.patch.object(in_the_matrix, 'tremble')
+  def test_initial_state_has_no_rng_side_effect(self, tremble):
+    self.assertTrue(self.puppeteer.initial_state())
+    tremble.assert_not_called()
+
+  @mock.patch.object(in_the_matrix, 'tremble', return_value=True)
+  def test_first_timestep_samples_opening_tremble_once(self, tremble):
+    timestep = dm_env.restart({
+        'INVENTORY': np.array([0, 0]),
+        'INTERACTION_INVENTORIES': np.array(([-1, -1], [-1, -1])),
+    })
+
+    transformed, state = self.puppeteer.step(
+        timestep, self.puppeteer.initial_state())
+
+    self.assertFalse(state)
+    self.assertIs(transformed.observation['GOAL'], _DEFECT.collect_goal)
+    tremble.assert_called_once_with(0.5)
+
+
+if __name__ == '__main__':
+  absltest.main()


### PR DESCRIPTION
## Summary

Make `TitForTat.initial_state()` side-effect free and sample the opening tremble only when processing the FIRST timestep.

The `Puppeteer` contract requires `initial_state()` to have no side effects. `TitForTat.initial_state()` currently calls `tremble()`, which advances the global random state. Normal policy startup calls `initial_state()` and then `step()` calls it again on a FIRST timestep, so two random samples are consumed even though the first result is discarded.

This change:
- makes `initial_state()` return the deterministic cooperative baseline
- applies the opening tremble exactly once when a FIRST timestep starts the episode
- preserves the existing first-step behavior for valid tremble probabilities
- leaves responses to later partner interactions unchanged
- adds focused regression coverage

## Testing

Added tests verifying that `initial_state()` does not call `tremble()` and that a FIRST timestep samples the opening tremble exactly once and uses that result for the initial strategy.