### PR TITLE
Label action spec subtests correctly

### DIFF
--- a/meltingpot/scenario_test.py
+++ b/meltingpot/scenario_test.py
@@ -37,7 +37,7 @@ class ScenarioTest(test_utils.SubstrateTestCase):
     with factory.build() as env:
       with self.subTest('step'):
         self.assert_step_matches_specs(env)
-      with self.subTest('discount_spec'):
+      with self.subTest('action_spec'):
         self.assertSequenceEqual(env.action_spec(), action_spec)
       with self.subTest('reward_spec'):
         self.assertSequenceEqual(env.reward_spec(), reward_spec)

--- a/meltingpot/substrate_test.py
+++ b/meltingpot/substrate_test.py
@@ -37,7 +37,7 @@ class PerSubstrateTestCase(test_utils.SubstrateTestCase):
     with factory.build(roles) as env:
       with self.subTest('step'):
         self.assert_step_matches_specs(env)
-      with self.subTest('discount_spec'):
+      with self.subTest('action_spec'):
         self.assertSequenceEqual(env.action_spec(), action_spec)
       with self.subTest('reward_spec'):
         self.assertSequenceEqual(env.reward_spec(), reward_spec)


### PR DESCRIPTION
## Summary

Correct the subtest labels used for action-spec assertions in the top-level substrate and scenario test suites.

Both tests currently run the `env.action_spec()` assertion inside `self.subTest('discount_spec')`. This gives the action-spec check the wrong diagnostic label and leaves two separate checks with the same `discount_spec` label.

This change:
- labels the action-spec assertions as `action_spec`
- leaves the assertions and test behavior unchanged
- keeps the actual discount-spec checks labeled `discount_spec`

## Testing

Test-only diagnostic change. The existing parameterized substrate and scenario suites continue to exercise the same assertions.