### PR TITLE
Remove stale RLlib devcontainer shared-memory override

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -8,12 +8,6 @@
       "PYTHON_VERSION": "3.11"
     }
   },
-  "runArgs": [
-    // Increase SHM sufficiently for RLlib. Note you can increase this
-    // further for performance gains (recommended to be at least 30% of RAM
-    // on large machines).
-    "--shm-size=6gb"
-  ],
   "postCreateCommand": "bin/install.sh",
   "customizations": {
     "vscode": {


### PR DESCRIPTION
## Summary

Remove the RLlib-specific shared-memory override from the development container configuration.

The devcontainer currently reserves 6 GB of shared memory specifically for RLlib workloads. The RLlib and Gym examples were removed from the repository as stale and untested, so the project no longer contains the workload this override was introduced to support.

This change:
- removes the RLlib-specific `--shm-size=6gb` run argument
- removes the associated stale RLlib guidance
- leaves the devcontainer image, Python version, install command, and editor configuration unchanged

## Testing

Configuration-only cleanup. The resulting `devcontainer.json` retains the existing build and post-create configuration without the obsolete RLlib run argument.