### PR TITLE
Add subprocess vectorized substrate execution

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -4,5 +4,6 @@
 
 *   [How to extend Melting Pot](extending.md)
 *   [Adding new substrates](substrates.md)
+*   [Vectorized substrate execution](vectorized_environments.md)
 *   [Concepts](concepts.md)
 *   [Advanced](advanced.md)

--- a/docs/vectorized_environments.md
+++ b/docs/vectorized_environments.md
@@ -1,0 +1,81 @@
+# Vectorized substrate execution
+
+Melting Pot substrates contain a live DMLab2D environment. That object is not
+picklable, so process-based vectorizers that try to serialize an already-built
+substrate can fail with errors such as:
+
+```text
+TypeError: cannot pickle 'dmlab2d.dmlab2d_pybind.Lab2d' object
+```
+
+Use `meltingpot.substrate.build_vectorized` when several independent copies of
+the same substrate should run concurrently. It starts one worker process per
+environment and constructs DMLab2D inside that worker, so the live engine never
+crosses a process boundary.
+
+```python
+from meltingpot import substrate
+
+
+def main():
+  name = "prisoners_dilemma_in_the_matrix__arena"
+  config = substrate.get_config(name)
+  roles = config.default_player_roles
+
+  with substrate.build_vectorized(
+      name,
+      roles=roles,
+      num_envs=4,
+  ) as env:
+    timesteps = list(env.reset())
+
+    actions = [
+        [0] * len(roles)
+        for _ in range(env.num_envs)
+    ]
+    timesteps = list(env.step(actions))
+
+    # Environments can end on different steps. Reset only the workers that
+    # reached a terminal timestep before the next vector step, and keep their
+    # fresh initial observations for action selection.
+    for index, timestep in enumerate(timesteps):
+      if timestep.last():
+        timesteps[index] = env.reset_at(index)
+
+
+if __name__ == "__main__":
+  main()
+```
+
+The `if __name__ == "__main__"` guard is required when using Python's `spawn`
+multiprocessing start method. `spawn` is the default because it avoids
+inheriting live DMLab2D or TensorFlow state into child processes.
+
+## API
+
+`reset()` resets every worker and returns one `dm_env.TimeStep` per environment.
+Pass `indices` to reset only selected workers, or use `reset_at(index)` for one
+environment. This is useful when vector members finish episodes at different
+times.
+
+`step(actions)` accepts one multi-player action sequence per environment. The
+commands are sent to all workers before responses are collected, allowing the
+environments to execute concurrently.
+
+`action_spec()`, `observation_spec()`, `reward_spec()`, and `discount_spec()`
+return the corresponding spec for one member substrate. All workers created by
+`build_vectorized` use the same substrate and role assignment.
+
+`observation()` and `events()` return one value per worker. `close()` is
+idempotent and shuts down all worker processes; using the vector environment as
+a context manager is recommended.
+
+If a worker raises an exception, the parent raises
+`VectorEnvWorkerError` with the worker index, remote exception type, message,
+and traceback. Responses from the other workers are still drained so that a
+handled worker error does not desynchronize subsequent requests.
+
+This provides native Melting Pot process-level vectorization without requiring
+the underlying DMLab2D object itself to be picklable. Compatibility layers such
+as Gymnasium or PettingZoo can adapt the returned native Melting Pot timesteps
+as needed.

--- a/meltingpot/substrate.py
+++ b/meltingpot/substrate.py
@@ -33,9 +33,12 @@ from collections.abc import Sequence
 from meltingpot.configs import substrates as substrate_configs
 from meltingpot.utils.substrates import substrate
 from meltingpot.utils.substrates import substrate_factory
+from meltingpot.utils.substrates import vector_env
 from ml_collections import config_dict
 
 SUBSTRATES = substrate_configs.SUBSTRATES
+SubprocessVectorEnv = vector_env.SubprocessVectorEnv
+VectorEnvWorkerError = vector_env.VectorEnvWorkerError
 
 
 def get_config(name: str) -> config_dict.ConfigDict:
@@ -68,6 +71,52 @@ def build(name: str, *, roles: Sequence[str]) -> substrate.Substrate:
     The training substrate.
   """
   return get_factory(name).build(roles)
+
+
+def build_vectorized(
+    name: str,
+    *,
+    roles: Sequence[str],
+    num_envs: int,
+    start_method: str = "spawn",
+) -> SubprocessVectorEnv:
+  """Builds independent copies of a substrate in worker processes.
+
+  Unlike vectorizers that attempt to pickle a live DMLab2D environment, this
+  function sends only a substrate name and role assignment to each worker. Each
+  worker constructs and owns its DMLab2D instance locally.
+
+  Args:
+    name: Name of the substrate.
+    roles: One role string per player, as for `build`.
+    num_envs: Number of independent substrate instances to run concurrently.
+    start_method: Python multiprocessing start method. `spawn` is the default to
+      avoid inheriting live DMLab2D or TensorFlow state into worker processes.
+
+  Returns:
+    A vector environment whose `reset` and `step` methods return one timestep
+    per member substrate.
+
+  Raises:
+    ValueError: if `num_envs` is not positive or a role is unsupported.
+    VectorEnvWorkerError: if a worker fails while constructing its substrate.
+  """
+  if num_envs <= 0:
+    raise ValueError("num_envs must be positive.")
+  factory = get_factory(name)
+  roles = tuple(roles)
+  invalid_roles = set(roles) - factory.valid_roles()
+  if invalid_roles:
+    raise ValueError(
+        f"Invalid roles: {invalid_roles!r}. Must be one of "
+        f"{factory.valid_roles()!r}"
+    )
+  return vector_env.build_vectorized(
+      name,
+      roles=roles,
+      num_envs=num_envs,
+      start_method=start_method,
+  )
 
 
 def build_from_config(

--- a/meltingpot/substrate_vectorized_test.py
+++ b/meltingpot/substrate_vectorized_test.py
@@ -1,0 +1,88 @@
+# Copyright 2026 DeepMind Technologies Limited.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Tests for the public vectorized substrate builder."""
+
+from unittest import mock
+
+from absl.testing import absltest
+from meltingpot import substrate
+from meltingpot.utils.substrates import vector_env
+
+
+class BuildVectorizedTest(absltest.TestCase):
+
+  def test_delegates_without_building_environment_in_parent(self):
+    factory = mock.Mock()
+    factory.valid_roles.return_value = frozenset({"default", "special"})
+    vectorized = mock.sentinel.vectorized
+
+    with mock.patch.object(substrate, "get_factory", return_value=factory):
+      with mock.patch.object(
+          vector_env, "build_vectorized", return_value=vectorized
+      ) as build_vectorized:
+        actual = substrate.build_vectorized(
+            "example",
+            roles=("default", "special"),
+            num_envs=4,
+            start_method="spawn",
+        )
+
+    self.assertIs(actual, vectorized)
+    build_vectorized.assert_called_once_with(
+        "example",
+        roles=("default", "special"),
+        num_envs=4,
+        start_method="spawn",
+    )
+
+  def test_rejects_nonpositive_num_envs_before_factory_lookup(self):
+    with mock.patch.object(substrate, "get_factory") as get_factory:
+      with self.assertRaisesRegex(ValueError, "num_envs must be positive"):
+        substrate.build_vectorized("example", roles=("default",), num_envs=0)
+    get_factory.assert_not_called()
+
+  def test_rejects_unsupported_roles_before_starting_workers(self):
+    factory = mock.Mock()
+    factory.valid_roles.return_value = frozenset({"default"})
+    with mock.patch.object(substrate, "get_factory", return_value=factory):
+      with mock.patch.object(vector_env, "build_vectorized") as build_vectorized:
+        with self.assertRaisesRegex(ValueError, "Invalid roles"):
+          substrate.build_vectorized(
+              "example", roles=("default", "unknown"), num_envs=2
+          )
+    build_vectorized.assert_not_called()
+
+  def test_builds_and_steps_real_substrates_in_spawned_workers(self):
+    name = "prisoners_dilemma_in_the_matrix__repeated"
+    config = substrate.get_config(name)
+    roles = config.default_player_roles
+
+    with substrate.build_vectorized(
+        name,
+        roles=roles,
+        num_envs=2,
+        start_method="spawn",
+    ) as env:
+      reset = env.reset()
+      self.assertLen(reset, 2)
+      self.assertTrue(all(timestep.first() for timestep in reset))
+
+      actions = tuple((0,) * len(roles) for _ in range(env.num_envs))
+      stepped = env.step(actions)
+      self.assertLen(stepped, 2)
+      self.assertTrue(all(not timestep.first() for timestep in stepped))
+
+
+if __name__ == "__main__":
+  absltest.main()

--- a/meltingpot/utils/substrates/vector_env.py
+++ b/meltingpot/utils/substrates/vector_env.py
@@ -1,0 +1,425 @@
+# Copyright 2026 DeepMind Technologies Limited.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Subprocess-based vectorized execution for Melting Pot substrates."""
+
+from collections.abc import Callable, Mapping, Sequence
+import dataclasses
+import multiprocessing
+from multiprocessing.connection import Connection
+import sys
+import time
+import traceback
+from typing import Any
+
+import dm_env
+
+_READY = "ready"
+_RESULT = "result"
+_ERROR = "error"
+_RESET = "reset"
+_STEP = "step"
+_OBSERVATION = "observation"
+_EVENTS = "events"
+_CLOSE = "close"
+_CLOSE_TIMEOUT_SECONDS = 5.0
+
+
+@dataclasses.dataclass(frozen=True)
+class _RemoteException:
+  exception_type: str
+  message: str
+  traceback: str
+
+
+@dataclasses.dataclass(frozen=True)
+class _EnvironmentSpecs:
+  action: Any
+  observation: Any
+  reward: Any
+  discount: Any
+
+
+@dataclasses.dataclass(frozen=True)
+class _SubstrateBuilder:
+  name: str
+  roles: tuple[str, ...]
+
+  def __call__(self):
+    # Import lazily so the worker can import this module without creating a
+    # circular import through the public meltingpot.substrate module.
+    from meltingpot import substrate as substrate_api  # pylint: disable=g-import-not-at-top
+    return substrate_api.build(self.name, roles=self.roles)
+
+
+class VectorEnvWorkerError(RuntimeError):
+  """Raised when one vector-environment worker fails."""
+
+  def __init__(
+      self,
+      worker_index: int,
+      exception_type: str,
+      message: str,
+      remote_traceback: str = "",
+  ) -> None:
+    self.worker_index = worker_index
+    self.exception_type = exception_type
+    self.remote_traceback = remote_traceback
+    detail = f"Worker {worker_index} raised {exception_type}: {message}"
+    if remote_traceback:
+      detail += f"\nRemote traceback:\n{remote_traceback}"
+    super().__init__(detail)
+
+
+def _serialize_exception() -> _RemoteException:
+  current = sys.exc_info()[1]
+  assert current is not None
+  return _RemoteException(
+      exception_type=type(current).__name__,
+      message=str(current),
+      traceback=traceback.format_exc(),
+  )
+
+
+def _worker(connection: Connection, builder: Callable[[], Any]) -> None:
+  """Owns one environment and serves synchronous commands from the parent."""
+  env = None
+  try:
+    env = builder()
+    specs = _EnvironmentSpecs(
+        action=env.action_spec(),
+        observation=env.observation_spec(),
+        reward=env.reward_spec(),
+        discount=env.discount_spec(),
+    )
+    connection.send((_READY, specs))
+
+    while True:
+      try:
+        command, payload = connection.recv()
+      except EOFError:
+        break
+
+      if command == _CLOSE:
+        try:
+          env.close()
+        finally:
+          env = None
+        break
+
+      try:
+        if command == _RESET:
+          result = env.reset()
+        elif command == _STEP:
+          result = env.step(payload)
+        elif command == _OBSERVATION:
+          result = env.observation()
+        elif command == _EVENTS:
+          result = tuple(env.events())
+        else:
+          raise ValueError(f"Unknown vector environment command: {command!r}")
+      except BaseException:  # pylint: disable=broad-except
+        connection.send((_ERROR, _serialize_exception()))
+      else:
+        connection.send((_RESULT, result))
+  except BaseException:  # pylint: disable=broad-except
+    try:
+      connection.send((_ERROR, _serialize_exception()))
+    except (BrokenPipeError, EOFError, OSError):
+      pass
+  finally:
+    if env is not None:
+      try:
+        env.close()
+      except BaseException:  # pylint: disable=broad-except
+        pass
+    connection.close()
+
+
+class SubprocessVectorEnv:
+  """Runs multiple independent environments in worker processes.
+
+  Commands are sent to all selected workers before any response is collected,
+  allowing the underlying environments to execute concurrently. Environment
+  objects themselves never cross a process boundary; only picklable builders,
+  actions, timesteps, observations, events, specs, and errors are transferred.
+  """
+
+  def __init__(
+      self,
+      builders: Sequence[Callable[[], Any]],
+      *,
+      start_method: str = "spawn",
+  ) -> None:
+    """Starts one worker process for each environment builder.
+
+    Args:
+      builders: Picklable callables that each construct one environment.
+      start_method: multiprocessing start method. ``spawn`` is the default to
+        avoid inheriting live DMLab2D or TensorFlow state into workers.
+
+    Raises:
+      ValueError: if no builders are supplied or the start method is invalid.
+      VectorEnvWorkerError: if an environment cannot be constructed.
+    """
+    builders = tuple(builders)
+    if not builders:
+      raise ValueError("At least one environment builder is required.")
+
+    self._closed = False
+    self._connections: list[Connection] = []
+    self._processes: list[multiprocessing.Process] = []
+    self._start_method = start_method
+
+    try:
+      context = multiprocessing.get_context(start_method)
+      for worker_index, builder in enumerate(builders):
+        parent_connection, child_connection = context.Pipe()
+        process = context.Process(
+            target=_worker,
+            args=(child_connection, builder),
+            name=f"meltingpot-vector-env-{worker_index}",
+        )
+        try:
+          process.start()
+        except BaseException:
+          parent_connection.close()
+          child_connection.close()
+          raise
+        child_connection.close()
+        self._connections.append(parent_connection)
+        self._processes.append(process)
+
+      worker_indices = tuple(range(len(self._connections)))
+      specs = self._receive_many(worker_indices, expected_kind=_READY)
+      self._specs = specs[0]
+    except BaseException:
+      self.close()
+      raise
+
+  @property
+  def num_envs(self) -> int:
+    """Number of independently running environments."""
+    return len(self._connections)
+
+  @property
+  def start_method(self) -> str:
+    """Multiprocessing start method used by the workers."""
+    return self._start_method
+
+  def action_spec(self):
+    """Returns the action spec for one member environment."""
+    return self._specs.action
+
+  def observation_spec(self):
+    """Returns the observation spec for one member environment."""
+    return self._specs.observation
+
+  def reward_spec(self):
+    """Returns the reward spec for one member environment."""
+    return self._specs.reward
+
+  def discount_spec(self):
+    """Returns the discount spec for one member environment."""
+    return self._specs.discount
+
+  def reset(
+      self, indices: Sequence[int] | None = None
+  ) -> tuple[dm_env.TimeStep, ...]:
+    """Resets all or selected member environments.
+
+    Args:
+      indices: worker indices to reset. If omitted, resets every environment.
+
+    Returns:
+      Timesteps in the same order as ``indices`` (or worker order when omitted).
+    """
+    worker_indices = self._normalize_indices(indices)
+    payloads = {index: None for index in worker_indices}
+    return self._request_many(_RESET, payloads)
+
+  def reset_at(self, index: int) -> dm_env.TimeStep:
+    """Resets one member environment and returns its initial timestep."""
+    return self.reset((index,))[0]
+
+  def step(
+      self, actions: Sequence[Sequence[int]]
+  ) -> tuple[dm_env.TimeStep, ...]:
+    """Steps every environment concurrently.
+
+    Args:
+      actions: one multi-player action sequence per environment.
+
+    Returns:
+      One timestep per environment, in worker order.
+
+    Raises:
+      ValueError: if the number of action batches does not match ``num_envs``.
+    """
+    self._ensure_open()
+    actions = tuple(actions)
+    if len(actions) != self.num_envs:
+      raise ValueError(
+          f"Expected actions for {self.num_envs} environments, got "
+          f"{len(actions)}."
+      )
+    payloads = {index: action for index, action in enumerate(actions)}
+    return self._request_many(_STEP, payloads)
+
+  def observation(self) -> tuple[Any, ...]:
+    """Returns the current observation from every environment."""
+    worker_indices = tuple(range(self.num_envs))
+    payloads = {index: None for index in worker_indices}
+    return self._request_many(_OBSERVATION, payloads)
+
+  def events(self) -> tuple[tuple[Any, ...], ...]:
+    """Returns current events from every environment."""
+    worker_indices = tuple(range(self.num_envs))
+    payloads = {index: None for index in worker_indices}
+    return self._request_many(_EVENTS, payloads)
+
+  def close(self) -> None:
+    """Closes every worker and its underlying environment."""
+    if self._closed:
+      return
+    self._closed = True
+
+    for connection, process in zip(self._connections, self._processes):
+      if not process.is_alive():
+        continue
+      try:
+        connection.send((_CLOSE, None))
+      except (BrokenPipeError, EOFError, OSError):
+        pass
+
+    deadline = time.monotonic() + _CLOSE_TIMEOUT_SECONDS
+    for process in self._processes:
+      remaining = max(0.0, deadline - time.monotonic())
+      process.join(timeout=remaining)
+
+    for process in self._processes:
+      if process.is_alive():
+        process.terminate()
+    for process in self._processes:
+      if process.is_alive():
+        process.join()
+
+    for connection in self._connections:
+      connection.close()
+
+  def __enter__(self):
+    return self
+
+  def __exit__(self, *args, **kwargs):
+    del args, kwargs
+    self.close()
+
+  def _ensure_open(self) -> None:
+    if self._closed:
+      raise RuntimeError("Vector environment is closed.")
+
+  def _normalize_indices(
+      self, indices: Sequence[int] | None
+  ) -> tuple[int, ...]:
+    self._ensure_open()
+    if indices is None:
+      return tuple(range(self.num_envs))
+    normalized = tuple(indices)
+    if len(set(normalized)) != len(normalized):
+      raise ValueError("Worker indices must not contain duplicates.")
+    for index in normalized:
+      if index < 0 or index >= self.num_envs:
+        raise IndexError(
+            f"Worker index {index} is outside [0, {self.num_envs})."
+        )
+    return normalized
+
+  def _request_many(
+      self, command: str, payloads: Mapping[int, Any]
+  ) -> tuple[Any, ...]:
+    self._ensure_open()
+    worker_indices = tuple(payloads)
+    sent_indices = []
+    send_error = None
+
+    for index in worker_indices:
+      try:
+        self._connections[index].send((command, payloads[index]))
+      except (BrokenPipeError, EOFError, OSError) as error:
+        if send_error is None:
+          send_error = VectorEnvWorkerError(
+              index, "ConnectionError", str(error)
+          )
+      else:
+        sent_indices.append(index)
+
+    results = self._receive_many(tuple(sent_indices), expected_kind=_RESULT)
+    if send_error is not None:
+      raise send_error
+    results_by_index = dict(zip(sent_indices, results))
+    return tuple(results_by_index[index] for index in worker_indices)
+
+  def _receive_many(
+      self, worker_indices: Sequence[int], *, expected_kind: str
+  ) -> tuple[Any, ...]:
+    results = []
+    first_error = None
+    for index in worker_indices:
+      try:
+        results.append(self._receive_one(index, expected_kind=expected_kind))
+      except VectorEnvWorkerError as error:
+        if first_error is None:
+          first_error = error
+        results.append(None)
+    if first_error is not None:
+      raise first_error
+    return tuple(results)
+
+  def _receive_one(self, index: int, *, expected_kind: str) -> Any:
+    try:
+      kind, payload = self._connections[index].recv()
+    except (EOFError, OSError) as error:
+      raise VectorEnvWorkerError(
+          index, "ConnectionError", "Worker process exited unexpectedly."
+      ) from error
+
+    if kind == _ERROR:
+      assert isinstance(payload, _RemoteException)
+      raise VectorEnvWorkerError(
+          index,
+          payload.exception_type,
+          payload.message,
+          payload.traceback,
+      )
+    if kind != expected_kind:
+      raise VectorEnvWorkerError(
+          index,
+          "ProtocolError",
+          f"Expected response {expected_kind!r}, received {kind!r}.",
+      )
+    return payload
+
+
+def build_vectorized(
+    name: str,
+    *,
+    roles: Sequence[str],
+    num_envs: int,
+    start_method: str = "spawn",
+) -> SubprocessVectorEnv:
+  """Builds multiple copies of one Melting Pot substrate in subprocesses."""
+  if num_envs <= 0:
+    raise ValueError("num_envs must be positive.")
+  builder = _SubstrateBuilder(name=name, roles=tuple(roles))
+  builders = tuple(builder for _ in range(num_envs))
+  return SubprocessVectorEnv(builders, start_method=start_method)

--- a/meltingpot/utils/substrates/vector_env.py
+++ b/meltingpot/utils/substrates/vector_env.py
@@ -185,7 +185,7 @@ class SubprocessVectorEnv:
       context = multiprocessing.get_context(start_method)
       for worker_index, builder in enumerate(builders):
         parent_connection, child_connection = context.Pipe()
-        process = context.Process(
+        process = context.Process(  # pytype: disable=attribute-error
             target=_worker,
             args=(child_connection, builder),
             name=f"meltingpot-vector-env-{worker_index}",

--- a/meltingpot/utils/substrates/vector_env_test.py
+++ b/meltingpot/utils/substrates/vector_env_test.py
@@ -1,0 +1,214 @@
+# Copyright 2026 DeepMind Technologies Limited.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Tests for subprocess vectorized environments."""
+
+import dataclasses
+
+from absl.testing import absltest
+import dm_env
+from meltingpot.utils.substrates import vector_env
+import numpy as np
+
+
+_ACTION_SPEC = dm_env.specs.DiscreteArray(
+    num_values=10, dtype=np.int64, name="action"
+)
+_OBSERVATION_SPEC = {
+    "VALUE": dm_env.specs.Array(shape=(), dtype=np.int64, name="VALUE")
+}
+_REWARD_SPEC = dm_env.specs.Array(shape=(), dtype=np.float64, name="reward")
+_DISCOUNT_SPEC = dm_env.specs.BoundedArray(
+    shape=(), dtype=np.float64, minimum=0, maximum=1, name="discount"
+)
+
+
+class _FakeEnv:
+  """Small picklable environment used to exercise process boundaries."""
+
+  def __init__(self, initial_value: int) -> None:
+    self._initial_value = initial_value
+    self._value = initial_value
+
+  def _observation(self):
+    return (
+        {"VALUE": np.asarray(self._value, dtype=np.int64)},
+        {"VALUE": np.asarray(self._value + 1, dtype=np.int64)},
+    )
+
+  def reset(self) -> dm_env.TimeStep:
+    self._value = self._initial_value
+    return dm_env.TimeStep(
+        step_type=dm_env.StepType.FIRST,
+        reward=(0.0, 0.0),
+        discount=1.0,
+        observation=self._observation(),
+    )
+
+  def step(self, action) -> dm_env.TimeStep:
+    if any(value < 0 for value in action):
+      raise ValueError("negative actions are invalid")
+    self._value += sum(action)
+    return dm_env.TimeStep(
+        step_type=dm_env.StepType.MID,
+        reward=(float(self._value), float(self._value)),
+        discount=1.0,
+        observation=self._observation(),
+    )
+
+  def observation(self):
+    return self._observation()
+
+  def events(self):
+    return (("value", self._value),)
+
+  def action_spec(self):
+    return (_ACTION_SPEC, _ACTION_SPEC)
+
+  def observation_spec(self):
+    return (_OBSERVATION_SPEC, _OBSERVATION_SPEC)
+
+  def reward_spec(self):
+    return (_REWARD_SPEC, _REWARD_SPEC)
+
+  def discount_spec(self):
+    return _DISCOUNT_SPEC
+
+  def close(self) -> None:
+    pass
+
+
+@dataclasses.dataclass(frozen=True)
+class _FakeBuilder:
+  initial_value: int
+
+  def __call__(self):
+    return _FakeEnv(self.initial_value)
+
+
+@dataclasses.dataclass(frozen=True)
+class _FailingBuilder:
+
+  def __call__(self):
+    raise RuntimeError("builder failed")
+
+
+def _value(timestep: dm_env.TimeStep) -> int:
+  return int(timestep.observation[0]["VALUE"])
+
+
+class SubprocessVectorEnvTest(absltest.TestCase):
+
+  def test_requires_at_least_one_builder(self):
+    with self.assertRaisesRegex(ValueError, "At least one"):
+      vector_env.SubprocessVectorEnv(())
+
+  def test_runs_workers_and_resets_independently(self):
+    with vector_env.SubprocessVectorEnv(
+        (_FakeBuilder(10), _FakeBuilder(20)), start_method="spawn"
+    ) as env:
+      self.assertEqual(env.num_envs, 2)
+      self.assertEqual(env.start_method, "spawn")
+
+      reset = env.reset()
+      self.assertEqual([_value(timestep) for timestep in reset], [10, 20])
+
+      stepped = env.step(((1, 2), (3, 4)))
+      self.assertEqual([_value(timestep) for timestep in stepped], [13, 27])
+
+      reset_second = env.reset(indices=(1,))
+      self.assertLen(reset_second, 1)
+      self.assertEqual(_value(reset_second[0]), 20)
+
+      observations = env.observation()
+      self.assertEqual(int(observations[0][0]["VALUE"]), 13)
+      self.assertEqual(int(observations[1][0]["VALUE"]), 20)
+      self.assertEqual(env.events(), ((('value', 13),), (('value', 20),)))
+
+  def test_exposes_member_environment_specs(self):
+    with vector_env.SubprocessVectorEnv(
+        (_FakeBuilder(0), _FakeBuilder(1)), start_method="spawn"
+    ) as env:
+      action_spec = env.action_spec()
+      self.assertLen(action_spec, 2)
+      self.assertEqual(action_spec[0].num_values, 10)
+      self.assertEqual(action_spec[0].dtype, np.dtype(np.int64))
+
+      observation_spec = env.observation_spec()
+      self.assertLen(observation_spec, 2)
+      self.assertEqual(observation_spec[0]["VALUE"].shape, ())
+      self.assertEqual(
+          observation_spec[0]["VALUE"].dtype, np.dtype(np.int64)
+      )
+
+      reward_spec = env.reward_spec()
+      self.assertLen(reward_spec, 2)
+      self.assertEqual(reward_spec[0].dtype, np.dtype(np.float64))
+
+      discount_spec = env.discount_spec()
+      self.assertEqual(discount_spec.minimum, 0)
+      self.assertEqual(discount_spec.maximum, 1)
+
+  def test_worker_error_reports_index_and_keeps_protocol_synchronized(self):
+    with vector_env.SubprocessVectorEnv(
+        (_FakeBuilder(0), _FakeBuilder(100)), start_method="spawn"
+    ) as env:
+      env.reset()
+      with self.assertRaisesRegex(
+          vector_env.VectorEnvWorkerError,
+          "Worker 1 raised ValueError: negative actions are invalid",
+      ):
+        env.step(((1, 1), (-1, 0)))
+
+      # The successful worker response from the failed batch was drained, so a
+      # subsequent request still receives the correct response from each worker.
+      stepped = env.step(((1, 0), (2, 0)))
+      self.assertEqual([_value(timestep) for timestep in stepped], [3, 102])
+
+  def test_rejects_wrong_action_batch_size_before_sending(self):
+    with vector_env.SubprocessVectorEnv(
+        (_FakeBuilder(0), _FakeBuilder(0)), start_method="spawn"
+    ) as env:
+      with self.assertRaisesRegex(ValueError, "Expected actions for 2"):
+        env.step(((1, 2),))
+
+  def test_rejects_invalid_reset_indices(self):
+    with vector_env.SubprocessVectorEnv(
+        (_FakeBuilder(0), _FakeBuilder(0)), start_method="spawn"
+    ) as env:
+      with self.assertRaisesRegex(ValueError, "must not contain duplicates"):
+        env.reset(indices=(0, 0))
+      with self.assertRaisesRegex(IndexError, "outside"):
+        env.reset_at(2)
+
+  def test_reports_worker_startup_failures(self):
+    with self.assertRaisesRegex(
+        vector_env.VectorEnvWorkerError,
+        "Worker 1 raised RuntimeError: builder failed",
+    ):
+      vector_env.SubprocessVectorEnv(
+          (_FakeBuilder(0), _FailingBuilder()), start_method="spawn"
+      )
+
+  def test_operations_fail_after_close(self):
+    env = vector_env.SubprocessVectorEnv(
+        (_FakeBuilder(0),), start_method="spawn"
+    )
+    env.close()
+    env.close()
+    with self.assertRaisesRegex(RuntimeError, "closed"):
+      env.reset()
+
+
+if __name__ == "__main__":
+  absltest.main()


### PR DESCRIPTION
## Summary

Add native process-level vectorized execution for Melting Pot substrates.

Addresses #253.

Live Melting Pot substrates contain a `dmlab2d` `Lab2d` object, so process-based vectorizers that serialize an already-constructed environment can fail with:

`TypeError: cannot pickle 'dmlab2d.dmlab2d_pybind.Lab2d' object`

This change avoids serializing the engine entirely. `substrate.build_vectorized(...)` sends only a picklable substrate descriptor (name and roles) to each worker process. Every worker constructs and owns its own DMLab2D instance locally, and the parent exchanges only actions, timesteps, observations, events, specs, and error information.

The vector environment:
- uses one independent process per substrate instance
- defaults to the `spawn` multiprocessing method so workers do not inherit live DMLab2D/TensorFlow state
- fans out step/reset requests before collecting responses, allowing environments to execute concurrently
- supports resetting only selected workers when episodes end at different times
- exposes the member substrate action/observation/reward/discount specs
- propagates worker exceptions with the worker index and remote traceback
- drains successful worker responses when another worker fails, keeping the request protocol synchronized
- bounds worker shutdown time and terminates stragglers
- shuts workers down through an idempotent `close()` and context-manager interface

A new guide documents the API, multiprocessing main-guard requirement, selective resets, and how compatibility layers can adapt the returned native Melting Pot timesteps.

## Testing

Added subprocess tests using the `spawn` start method covering:
- concurrent reset and step across multiple workers
- selective worker resets
- observations, events, and specs
- action-batch/index validation
- worker startup failures
- remote exception propagation
- protocol synchronization after one worker errors
- bounded, idempotent shutdown

Also added a real integration test that builds two `prisoners_dilemma_in_the_matrix__repeated` DMLab2D substrates in spawned worker processes, resets them, and steps them in parallel.

I could not execute the repository test suite in this environment because the local runtime does not include the Melting Pot/dm_env dependencies; the new tests are included for upstream CI.
