### PR TITLE
Avoid duplicate opening sampling in RespondToPrevious

### DIFF
--- a/meltingpot/utils/puppeteers/in_the_matrix.py
+++ b/meltingpot/utils/puppeteers/in_the_matrix.py
@@ -572,7 +572,7 @@ class RespondToPrevious(puppeteer.Puppeteer[Resource]):
 
   def initial_state(self) -> Resource:
     """See base class."""
-    return random.choice(list(self._responses.values()))
+    return list(self._responses.values())[0]
 
   def step(
       self,
@@ -581,7 +581,7 @@ class RespondToPrevious(puppeteer.Puppeteer[Resource]):
   ) -> tuple[dm_env.TimeStep, Resource]:
     """See base class."""
     if timestep.first():
-      prev_state = self.initial_state()
+      prev_state = random.choice(list(self._responses.values()))
     partner_resource = partner_max_resource(timestep)
     response = self._responses.get(partner_resource, prev_state)  # pyrefly: ignore[no-matching-overload]
     timestep = collect_or_interact_puppet_timestep(

--- a/meltingpot/utils/puppeteers/respond_to_previous_initial_state_test.py
+++ b/meltingpot/utils/puppeteers/respond_to_previous_initial_state_test.py
@@ -1,0 +1,72 @@
+# Copyright 2026 DeepMind Technologies Limited.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Regression tests for RespondToPrevious initialization."""
+
+from unittest import mock
+
+from absl.testing import absltest
+import dm_env
+from meltingpot.utils.puppeteers import in_the_matrix
+import numpy as np
+
+
+_RESOURCE_0 = in_the_matrix.Resource(
+    index=0,
+    collect_goal=mock.sentinel.collect_0,
+    interact_goal=mock.sentinel.interact_0,
+)
+_RESOURCE_1 = in_the_matrix.Resource(
+    index=1,
+    collect_goal=mock.sentinel.collect_1,
+    interact_goal=mock.sentinel.interact_1,
+)
+
+
+def _first_timestep():
+  return dm_env.restart({
+      'INVENTORY': np.array([0, 0]),
+      'INTERACTION_INVENTORIES': np.array([[-1, -1], [-1, -1]]),
+  })
+
+
+class RespondToPreviousInitialStateTest(absltest.TestCase):
+
+  def setUp(self):
+    super().setUp()
+    self._puppeteer = in_the_matrix.RespondToPrevious(
+        responses={_RESOURCE_0: _RESOURCE_0, _RESOURCE_1: _RESOURCE_1},
+        margin=1,
+    )
+
+  def test_initial_state_does_not_sample_random_target(self):
+    with mock.patch.object(in_the_matrix.random, 'choice') as choice:
+      state = self._puppeteer.initial_state()
+
+    choice.assert_not_called()
+    self.assertIs(state, _RESOURCE_0)
+
+  def test_first_timestep_samples_opening_target_once(self):
+    initial_state = self._puppeteer.initial_state()
+    with mock.patch.object(
+        in_the_matrix.random, 'choice', return_value=_RESOURCE_1
+    ) as choice:
+      timestep, state = self._puppeteer.step(_first_timestep(), initial_state)
+
+    choice.assert_called_once_with([_RESOURCE_0, _RESOURCE_1])
+    self.assertIs(state, _RESOURCE_1)
+    self.assertIs(timestep.observation['GOAL'], _RESOURCE_1.collect_goal)
+
+
+if __name__ == '__main__':
+  absltest.main()


### PR DESCRIPTION
## Summary

Make `RespondToPrevious.initial_state()` side-effect free and sample the random opening target only when processing the FIRST timestep.

The `Puppeteer` contract requires `initial_state()` to have no side effects. `RespondToPrevious.initial_state()` currently calls `random.choice()`. Normal policy startup calls `initial_state()` and then `step()` samples again for the FIRST timestep, so two random samples are consumed even though the first result is discarded.

This change:
- makes `initial_state()` return a deterministic baseline without consuming randomness
- samples the opening target exactly once on the FIRST timestep
- preserves the existing random opening-target behavior seen by the episode
- leaves later response selection unchanged
- adds focused regression coverage

## Testing

Added tests verifying that `initial_state()` does not call `random.choice()` and that a FIRST timestep samples exactly one opening target and uses it for the emitted goal.