### PR TITLE
Forward reset arguments through remaining substrate layers

### DIFF
--- a/meltingpot/utils/substrates/reset_argument_forwarding_test.py
+++ b/meltingpot/utils/substrates/reset_argument_forwarding_test.py
@@ -1,0 +1,59 @@
+# Copyright 2026 DeepMind Technologies Limited.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Tests for reset argument forwarding in the substrate stack."""
+
+from unittest import mock
+
+from absl.testing import absltest
+import dm_env
+from meltingpot.utils.substrates import substrate
+from meltingpot.utils.substrates.wrappers import multiplayer_wrapper
+
+
+class ResetArgumentForwardingTest(absltest.TestCase):
+
+  def test_multiplayer_wrapper_forwards_reset_arguments(self):
+    env = mock.Mock()
+    env.action_spec.return_value = {
+        '1.move': dm_env.specs.DiscreteArray(num_values=2, name='move'),
+    }
+    env.reset.return_value = dm_env.restart(observation={})
+    wrapper = multiplayer_wrapper.Wrapper(
+        env,
+        individual_observation_names=(),
+        global_observation_names=(),
+    )
+
+    wrapper.reset(mock.sentinel.argument, option=mock.sentinel.option)
+
+    env.reset.assert_called_once_with(
+        mock.sentinel.argument, option=mock.sentinel.option
+    )
+
+  def test_substrate_forwards_reset_arguments(self):
+    env = mock.Mock()
+    env.observables.return_value = mock.sentinel.observables
+    env.reset.return_value = dm_env.restart(observation=())
+    env.events.return_value = ()
+    wrapped = substrate.Substrate(env)
+
+    wrapped.reset(mock.sentinel.argument, option=mock.sentinel.option)
+
+    env.reset.assert_called_once_with(
+        mock.sentinel.argument, option=mock.sentinel.option
+    )
+
+
+if __name__ == '__main__':
+  absltest.main()

--- a/meltingpot/utils/substrates/substrate.py
+++ b/meltingpot/utils/substrates/substrate.py
@@ -63,9 +63,9 @@ class Substrate(base.Lab2dWrapper):
         dmlab2d=env.observables(),
     )
 
-  def reset(self) -> dm_env.TimeStep:
+  def reset(self, *args, **kwargs) -> dm_env.TimeStep:
     """See base class."""
-    timestep = super().reset()
+    timestep = super().reset(*args, **kwargs)
     self._timestep_subject.on_next(timestep)
     for event in super().events():
       self._events_subject.on_next(event)

--- a/meltingpot/utils/substrates/wrappers/multiplayer_wrapper.py
+++ b/meltingpot/utils/substrates/wrappers/multiplayer_wrapper.py
@@ -129,9 +129,9 @@ class Wrapper(observables.ObservableLab2dWrapper):
         dmlab2d_actions[f"{player_index + 1}.{key}"] = value
     return dmlab2d_actions
 
-  def reset(self) -> dm_env.TimeStep:
+  def reset(self, *args, **kwargs) -> dm_env.TimeStep:
     """See base class."""
-    timestep = super().reset()
+    timestep = super().reset(*args, **kwargs)
     return self._get_timestep(timestep)
 
   def step(


### PR DESCRIPTION
## Summary

Forward positional and keyword reset arguments through the remaining substrate layers that currently drop them.

`Lab2dWrapper.reset()` already accepts and forwards `*args` and `**kwargs`, but both `multiplayer_wrapper.Wrapper` and the public `Substrate` override `reset()` with zero-argument signatures.

This change:
- forwards reset arguments through `multiplayer_wrapper.Wrapper`
- forwards them through `Substrate`
- preserves timestep conversion and observable behavior
- adds focused regression coverage for both layers

## Testing

Added tests that pass positional and keyword reset arguments through each layer and verify that the underlying environment receives them unchanged.