### PR TITLE
Respect per-player action specs in ActionReader

### DIFF
--- a/meltingpot/human_players/action_reader_test.py
+++ b/meltingpot/human_players/action_reader_test.py
@@ -1,0 +1,62 @@
+# Copyright 2026 DeepMind Technologies Limited.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Tests for human-player action reading."""
+
+from unittest import mock
+
+from absl.testing import absltest
+from meltingpot.human_players import level_playing_utils
+
+
+class ActionReaderTest(absltest.TestCase):
+
+  def test_only_reads_actions_supported_by_selected_player(self):
+    env = mock.Mock()
+    env.action_spec.return_value = {
+        '1.move': mock.sentinel.move_spec,
+        '2.fire': mock.sentinel.fire_spec,
+    }
+    move = mock.Mock(return_value=3)
+    fire = mock.Mock(return_value=1)
+    reader = level_playing_utils.ActionReader(
+        env, {'move': move, 'fire': fire}
+    )
+
+    player_one_actions = reader.step('1')
+
+    self.assertEqual(player_one_actions, {'1.move': 3, '2.fire': 0})
+    move.assert_called_once_with()
+    fire.assert_not_called()
+
+  def test_uses_other_players_own_action_names(self):
+    env = mock.Mock()
+    env.action_spec.return_value = {
+        '1.move': mock.sentinel.move_spec,
+        '2.fire': mock.sentinel.fire_spec,
+    }
+    move = mock.Mock(return_value=3)
+    fire = mock.Mock(return_value=1)
+    reader = level_playing_utils.ActionReader(
+        env, {'move': move, 'fire': fire}
+    )
+
+    player_two_actions = reader.step('2')
+
+    self.assertEqual(player_two_actions, {'1.move': 0, '2.fire': 1})
+    move.assert_not_called()
+    fire.assert_called_once_with()
+
+
+if __name__ == '__main__':
+  absltest.main()

--- a/meltingpot/human_players/level_playing_utils.py
+++ b/meltingpot/human_players/level_playing_utils.py
@@ -172,14 +172,16 @@ class ActionReader(object):
     self._action_spec = env.action_spec()
     assert isinstance(self._action_spec, dict)
     self._action_names = set()
+    self._action_names_by_player = collections.defaultdict(set)
     for action_key in self._action_spec.keys():
-      _, action_name = _split_key(action_key)
+      player_prefix, action_name = _split_key(action_key)
       self._action_names.add(action_name)
+      self._action_names_by_player[player_prefix].add(action_name)
 
   def step(self, player_prefix: str) -> Mapping[str, int]:
     """Update the actions of player `player_prefix`."""
     actions = {action_key: 0 for action_key in self._action_spec.keys()}
-    for action_name in self._action_names:
+    for action_name in self._action_names_by_player[player_prefix]:
       actions[f'{player_prefix}.{action_name}'] = self._action_map[
           action_name]()
     return actions


### PR DESCRIPTION
## Summary

Make the human-player `ActionReader` respect the action names actually available to each player.

The current implementation collects action names globally across the full DMLab2D action spec. When player action specs are asymmetric, selecting one player can therefore add action keys that do not exist for that player.

This change:
- records action names per player prefix
- reads only actions supported by the currently selected player
- continues emitting zero values for the other valid action-spec keys
- preserves existing behavior for symmetric player action specs
- adds focused regression coverage

## Testing

Added tests with asymmetric player action specs verifying that each selected player produces only its own valid action keys.