### PR TITLE
Add reproducible evaluation manifests

### DIFF
--- a/docs/advanced.md
+++ b/docs/advanced.md
@@ -54,3 +54,11 @@ engine. The specific order is as follows:
 For more details, see the
 [`DoUpdate`](https://github.com/google-deepmind/lab2d/blob/main/dmlab2d/system/grid_world/grid.cc)
 method of the engine's grid.
+
+## Reproducible evaluation artifacts
+
+Episode-level evaluation results can be accompanied by versioned SHA-256
+manifests that fingerprint both the recorded outcomes and the
+configuration used to define the evaluation. See
+[reproducible evaluation manifests](evaluation_manifests.md) for the hash
+boundary, verification API, and manifest format.

--- a/docs/evaluation_manifests.md
+++ b/docs/evaluation_manifests.md
@@ -1,0 +1,194 @@
+# Reproducible evaluation manifests
+
+Melting Pot evaluations return episode-level player names and returns as a
+`pandas.DataFrame`. Aggregate scores are convenient for comparison, but they do
+not identify the exact episode results or scenario configuration that produced
+them.
+
+`meltingpot.utils.evaluation.evaluation_manifest` can create a versioned,
+portable manifest for an evaluation. A manifest lets a later reader answer two
+separate questions:
+
+1. Are these exactly the episode-level results that were originally recorded?
+2. Does the current Melting Pot target still have the same evaluation-relevant
+   configuration?
+
+The two checks use independent SHA-256 digests.
+
+## Create a manifest while evaluating
+
+The convenience wrappers return the normal result DataFrame together with a
+manifest. Existing evaluation functions are unchanged.
+
+```python
+from meltingpot.utils.evaluation import evaluation_manifest
+
+results, manifest = evaluation_manifest.evaluate_saved_models_with_manifest(
+    saved_models={
+        "candidate": "/path/to/saved_model",
+    },
+    names_by_role={
+        "default": {"candidate"},
+    },
+    target="clean_up_20",
+    num_episodes=100,
+)
+
+manifest.write("clean_up_20.manifest.json")
+results.to_pickle("clean_up_20.results.pkl")
+```
+
+The same API is available for an already-built population through
+`evaluate_population_with_manifest`.
+
+A manifest can also be created after an evaluation:
+
+```python
+manifest = evaluation_manifest.create_manifest(results, "clean_up_20")
+```
+
+## Verify later
+
+```python
+import pandas as pd
+from meltingpot.utils.evaluation import evaluation_manifest
+
+results = pd.read_pickle("clean_up_20.results.pkl")
+manifest = evaluation_manifest.EvaluationManifest.read(
+    "clean_up_20.manifest.json"
+)
+
+evaluation_manifest.verify_manifest(manifest, results)
+```
+
+By default verification checks both the episode content and the current target
+configuration. If the result table has been changed, the error identifies the
+first episode whose leaf hash differs.
+
+Runtime package versions are recorded in the manifest for diagnostics but are
+not required to match by default. To require an exact runtime-version match:
+
+```python
+evaluation_manifest.verify_manifest(
+    manifest,
+    results,
+    check_runtime=True,
+)
+```
+
+To check a result artifact even when the currently installed scenario
+configuration has intentionally changed:
+
+```python
+evaluation_manifest.verify_manifest(
+    manifest,
+    results,
+    check_configuration=False,
+)
+```
+
+## What the content hash covers
+
+Each episode is canonicalized as an ordered list of focal and background
+players. Every player entry binds:
+
+* the policy/bot name, and
+* the exact episode return.
+
+Finite floating-point values are encoded using Python's exact hexadecimal
+floating-point representation. NaN, positive infinity, and negative infinity
+have explicit canonical tokens. This avoids relying on JSON's implementation-
+dependent floating-point formatting.
+
+The following fields are deliberately not part of the content hash:
+
+* `video_path`, because it is machine-specific,
+* the DataFrame index, because it is storage metadata, and
+* per-capita return columns, because they are derived from the player returns
+  already committed by the hash.
+
+Episode order is part of the content. Reordering rows changes the root.
+
+## Merkle construction
+
+Schema version 1 uses domain-separated SHA-256 hashes.
+
+For an episode's canonical JSON bytes `record`:
+
+```text
+leaf = SHA256(0x00 || record)
+```
+
+Parent nodes are:
+
+```text
+parent = SHA256(0x01 || left || right)
+```
+
+When a tree level has an odd number of nodes, the final node is duplicated
+before hashing the next level. An empty evaluation uses:
+
+```text
+SHA256(0x02)
+```
+
+The manifest stores every leaf digest as `episode_sha256` and the final root as
+`content_sha256`. Keeping the leaves makes a mismatch localizable without
+having to compare full result files.
+
+## What the configuration hash covers
+
+The separate `configuration_sha256` digest is intended to detect evaluation
+definition drift.
+
+For a scenario it commits to:
+
+* the underlying substrate name,
+* every player role in slot order,
+* every focal/background assignment in slot order,
+* the complete background bot pool for each role,
+* each referenced background bot's substrate, supported roles, model identity,
+  and puppeteer constructor configuration, and
+* the underlying substrate's public action, timestep, observation, and role
+  signature.
+
+For a direct substrate evaluation it also commits to the default player-role
+assignment, because that assignment is used by the evaluation helper.
+
+Descriptive scenario text and tags are excluded because changing documentation
+does not change evaluation semantics.
+
+The configuration object is canonicalized before hashing, including mappings,
+sets, NumPy arrays/scalars, dataclasses, callables, and `functools.partial`
+objects used by puppeteer builders.
+
+## Runtime metadata
+
+The manifest records the Python version and installed versions of:
+
+* `dm-meltingpot`,
+* `dmlab2d`,
+* `dm-env`,
+* `numpy`,
+* `pandas`, and
+* `tensorflow`.
+
+These fields help diagnose differences between runs. They are not included in
+the episode Merkle root and are only enforced by `verify_manifest` when
+`check_runtime=True`.
+
+## Scope and limitations
+
+An evaluation manifest is an integrity and reproducibility record, not a
+cryptographic signature. Anyone who can replace both a result file and its
+manifest can compute a new valid hash. Authenticity requires a separate signing
+or trusted publication mechanism.
+
+The configuration digest intentionally focuses on evaluation-relevant public
+configuration. It records background model identity, but it does not hash every
+byte of saved-model assets or the entire Melting Pot source tree. The episode
+content root and recorded runtime versions complement that configuration
+fingerprint.
+
+The schema version is stored explicitly so the canonicalization or hash boundary
+can evolve without silently changing the meaning of an existing digest.

--- a/meltingpot/utils/evaluation/evaluation_manifest.py
+++ b/meltingpot/utils/evaluation/evaluation_manifest.py
@@ -1,0 +1,669 @@
+# Copyright 2026 DeepMind Technologies Limited.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Reproducible manifests for Melting Pot evaluation results."""
+
+from collections.abc import Collection, Mapping, Sequence
+import dataclasses
+import functools
+import hashlib
+import importlib.metadata
+import json
+import math
+import pathlib
+import platform
+from typing import Any
+
+from meltingpot import bot as bot_lib
+from meltingpot.configs import bots as bot_configs
+from meltingpot.configs import scenarios as scenario_configs
+from meltingpot.configs import substrates as substrate_configs
+import numpy as np
+import pandas as pd
+
+SCHEMA_VERSION = 1
+_HASH_ALGORITHM = 'sha256'
+_REQUIRED_RESULT_COLUMNS = frozenset({
+    'background_player_names',
+    'background_player_returns',
+    'focal_player_names',
+    'focal_player_returns',
+})
+_RUNTIME_DISTRIBUTIONS = (
+    'dm-env',
+    'dm-meltingpot',
+    'dmlab2d',
+    'numpy',
+    'pandas',
+    'tensorflow',
+)
+
+
+class EvaluationManifestMismatch(ValueError):
+  """Raised when results or configuration do not match a manifest."""
+
+
+@dataclasses.dataclass(frozen=True)
+class EvaluationManifest:
+  """Versioned fingerprint of one evaluation result table.
+
+  Attributes:
+    schema_version: manifest schema version.
+    hash_algorithm: digest algorithm used by this schema.
+    target: evaluated scenario or substrate name.
+    target_kind: either ``scenario`` or ``substrate``.
+    configuration_sha256: digest of the target's evaluation-relevant public
+      configuration.
+    content_sha256: Merkle root over all episode result records.
+    episode_sha256: leaf digest for each episode, in evaluation order.
+    num_episodes: number of result rows represented by the manifest.
+    runtime_versions: sorted ``(name, version)`` pairs recorded for diagnostics.
+  """
+  schema_version: int
+  hash_algorithm: str
+  target: str
+  target_kind: str
+  configuration_sha256: str
+  content_sha256: str
+  episode_sha256: tuple[str, ...]
+  num_episodes: int
+  runtime_versions: tuple[tuple[str, str], ...]
+
+  def to_dict(self) -> dict[str, Any]:
+    """Returns a JSON-compatible representation."""
+    return {
+        'schema_version': self.schema_version,
+        'hash_algorithm': self.hash_algorithm,
+        'target': self.target,
+        'target_kind': self.target_kind,
+        'configuration_sha256': self.configuration_sha256,
+        'content_sha256': self.content_sha256,
+        'episode_sha256': list(self.episode_sha256),
+        'num_episodes': self.num_episodes,
+        'runtime_versions': dict(self.runtime_versions),
+    }
+
+  def to_json(self, *, indent: int | None = 2) -> str:
+    """Serializes the manifest as deterministic JSON."""
+    return json.dumps(
+        self.to_dict(),
+        sort_keys=True,
+        ensure_ascii=False,
+        indent=indent,
+    )
+
+  def write(self, path: str | pathlib.Path) -> None:
+    """Writes the manifest to ``path`` as UTF-8 JSON."""
+    pathlib.Path(path).write_text(self.to_json() + '\n', encoding='utf-8')
+
+  @classmethod
+  def from_dict(cls, value: Mapping[str, Any]) -> 'EvaluationManifest':
+    """Builds and validates a manifest from a mapping."""
+    required = {
+        'schema_version',
+        'hash_algorithm',
+        'target',
+        'target_kind',
+        'configuration_sha256',
+        'content_sha256',
+        'episode_sha256',
+        'num_episodes',
+        'runtime_versions',
+    }
+    missing = required - set(value)
+    if missing:
+      raise ValueError(f'Manifest is missing fields: {sorted(missing)!r}.')
+
+    schema_version = int(value['schema_version'])
+    if schema_version != SCHEMA_VERSION:
+      raise ValueError(
+          f'Unsupported evaluation manifest schema: {schema_version}.'
+      )
+    hash_algorithm = str(value['hash_algorithm'])
+    if hash_algorithm != _HASH_ALGORITHM:
+      raise ValueError(f'Unsupported hash algorithm: {hash_algorithm!r}.')
+
+    target_kind = str(value['target_kind'])
+    if target_kind not in ('scenario', 'substrate'):
+      raise ValueError(f'Invalid target kind: {target_kind!r}.')
+
+    configuration_digest = str(value['configuration_sha256'])
+    content_digest = str(value['content_sha256'])
+    _validate_digest(configuration_digest, 'configuration_sha256')
+    _validate_digest(content_digest, 'content_sha256')
+
+    episode_digests = tuple(str(digest) for digest in value['episode_sha256'])
+    for digest in episode_digests:
+      _validate_digest(digest, 'episode_sha256')
+
+    num_episodes = int(value['num_episodes'])
+    if num_episodes < 0:
+      raise ValueError('num_episodes must not be negative.')
+    if len(episode_digests) != num_episodes:
+      raise ValueError(
+          'episode_sha256 length does not match num_episodes: '
+          f'{len(episode_digests)} != {num_episodes}.'
+      )
+
+    runtime_versions_value = value['runtime_versions']
+    if not isinstance(runtime_versions_value, Mapping):
+      raise ValueError('runtime_versions must be a mapping.')
+    runtime_versions = tuple(
+        sorted(
+            (str(name), str(version))
+            for name, version in runtime_versions_value.items()
+        )
+    )
+
+    return cls(
+        schema_version=schema_version,
+        hash_algorithm=hash_algorithm,
+        target=str(value['target']),
+        target_kind=target_kind,
+        configuration_sha256=configuration_digest,
+        content_sha256=content_digest,
+        episode_sha256=episode_digests,
+        num_episodes=num_episodes,
+        runtime_versions=runtime_versions,
+    )
+
+  @classmethod
+  def from_json(cls, value: str) -> 'EvaluationManifest':
+    """Parses a manifest from JSON text."""
+    decoded = json.loads(value)
+    if not isinstance(decoded, Mapping):
+      raise ValueError('Evaluation manifest JSON must contain an object.')
+    return cls.from_dict(decoded)
+
+  @classmethod
+  def read(cls, path: str | pathlib.Path) -> 'EvaluationManifest':
+    """Reads a manifest from a UTF-8 JSON file."""
+    return cls.from_json(pathlib.Path(path).read_text(encoding='utf-8'))
+
+
+def create_manifest(results: pd.DataFrame, target: str) -> EvaluationManifest:
+  """Creates a reproducibility manifest for evaluation results.
+
+  Args:
+    results: DataFrame returned by Melting Pot evaluation utilities.
+    target: scenario or substrate name evaluated to produce ``results``.
+
+  Returns:
+    A versioned manifest containing per-episode digests, a Merkle content root,
+    a target configuration digest, and runtime version metadata.
+  """
+  target_kind = _target_kind(target)
+  episode_digests = episode_hashes(results)
+  return EvaluationManifest(
+      schema_version=SCHEMA_VERSION,
+      hash_algorithm=_HASH_ALGORITHM,
+      target=target,
+      target_kind=target_kind,
+      configuration_sha256=configuration_hash(target),
+      content_sha256=_merkle_root(episode_digests),
+      episode_sha256=episode_digests,
+      num_episodes=len(results),
+      runtime_versions=_runtime_versions(),
+  )
+
+
+def verify_manifest(
+    manifest: EvaluationManifest,
+    results: pd.DataFrame,
+    *,
+    check_configuration: bool = True,
+    check_runtime: bool = False,
+) -> None:
+  """Verifies results and, optionally, the current runtime against a manifest.
+
+  Args:
+    manifest: previously created evaluation manifest.
+    results: result table to verify.
+    check_configuration: also verify the current target configuration digest.
+    check_runtime: also require recorded runtime package versions to match the
+      current runtime exactly.
+
+  Raises:
+    EvaluationManifestMismatch: if any requested check does not match.
+    ValueError: if the manifest schema itself is unsupported.
+  """
+  if manifest.schema_version != SCHEMA_VERSION:
+    raise ValueError(
+        f'Unsupported evaluation manifest schema: {manifest.schema_version}.'
+    )
+  if manifest.hash_algorithm != _HASH_ALGORITHM:
+    raise ValueError(
+        f'Unsupported hash algorithm: {manifest.hash_algorithm!r}.'
+    )
+
+  actual_episode_hashes = episode_hashes(results)
+  if len(actual_episode_hashes) != manifest.num_episodes:
+    raise EvaluationManifestMismatch(
+        'Episode count mismatch: '
+        f'expected {manifest.num_episodes}, got {len(actual_episode_hashes)}.'
+    )
+
+  for index, (expected, actual) in enumerate(
+      zip(manifest.episode_sha256, actual_episode_hashes)
+  ):
+    if actual != expected:
+      raise EvaluationManifestMismatch(
+          f'Episode {index} content hash mismatch: '
+          f'expected {expected}, got {actual}.'
+      )
+
+  actual_content_hash = _merkle_root(actual_episode_hashes)
+  if actual_content_hash != manifest.content_sha256:
+    raise EvaluationManifestMismatch(
+        'Evaluation content hash mismatch: '
+        f'expected {manifest.content_sha256}, got {actual_content_hash}.'
+    )
+
+  actual_kind = _target_kind(manifest.target)
+  if actual_kind != manifest.target_kind:
+    raise EvaluationManifestMismatch(
+        f'Target kind mismatch for {manifest.target!r}: '
+        f'expected {manifest.target_kind!r}, got {actual_kind!r}.'
+    )
+
+  if check_configuration:
+    actual_configuration_hash = configuration_hash(manifest.target)
+    if actual_configuration_hash != manifest.configuration_sha256:
+      raise EvaluationManifestMismatch(
+          f'Configuration hash mismatch for {manifest.target!r}: '
+          f'expected {manifest.configuration_sha256}, '
+          f'got {actual_configuration_hash}.'
+      )
+
+  if check_runtime:
+    actual_runtime = _runtime_versions()
+    if actual_runtime != manifest.runtime_versions:
+      raise EvaluationManifestMismatch(
+          'Runtime versions do not match the evaluation manifest.'
+      )
+
+
+def episode_hashes(results: pd.DataFrame) -> tuple[str, ...]:
+  """Returns one SHA-256 leaf digest per evaluation episode."""
+  _validate_result_columns(results)
+  digests = []
+  for position in range(len(results)):
+    row = results.iloc[position]
+    payload = _episode_payload(row)
+    encoded = _canonical_json(payload)
+    digests.append(hashlib.sha256(b'\x00' + encoded).hexdigest())
+  return tuple(digests)
+
+
+def content_hash(results: pd.DataFrame) -> str:
+  """Returns the Merkle root over all evaluation episodes."""
+  return _merkle_root(episode_hashes(results))
+
+
+def configuration_hash(target: str) -> str:
+  """Returns a SHA-256 digest of evaluation-relevant target configuration."""
+  payload = _configuration_payload(target)
+  return hashlib.sha256(b'\x10' + _canonical_json(payload)).hexdigest()
+
+
+def _episode_payload(row: pd.Series) -> dict[str, Any]:
+  focal_names = _name_sequence(row['focal_player_names'], 'focal_player_names')
+  focal_returns = _return_sequence(
+      row['focal_player_returns'], 'focal_player_returns'
+  )
+  background_names = _name_sequence(
+      row['background_player_names'], 'background_player_names'
+  )
+  background_returns = _return_sequence(
+      row['background_player_returns'], 'background_player_returns'
+  )
+
+  if len(focal_names) != len(focal_returns):
+    raise ValueError(
+        'focal_player_names and focal_player_returns must have equal length.'
+    )
+  if len(background_names) != len(background_returns):
+    raise ValueError(
+        'background_player_names and background_player_returns must have '
+        'equal length.'
+    )
+
+  return {
+      'focal_players': [
+          {'name': name, 'return': return_value}
+          for name, return_value in zip(focal_names, focal_returns)
+      ],
+      'background_players': [
+          {'name': name, 'return': return_value}
+          for name, return_value in zip(background_names, background_returns)
+      ],
+  }
+
+
+def _name_sequence(value: Any, column: str) -> tuple[str, ...]:
+  values = _as_sequence(value, column)
+  names = []
+  for item in values:
+    if not isinstance(item, str):
+      raise ValueError(f'{column} must contain only strings.')
+    names.append(item)
+  return tuple(names)
+
+
+def _return_sequence(value: Any, column: str) -> tuple[str, ...]:
+  values = _as_sequence(value, column)
+  return tuple(_float_token(item, column) for item in values)
+
+
+def _as_sequence(value: Any, column: str) -> tuple[Any, ...]:
+  if isinstance(value, np.ndarray):
+    if value.ndim != 1:
+      raise ValueError(f'{column} must be one-dimensional.')
+    return tuple(value.tolist())
+  if isinstance(value, (str, bytes)) or not isinstance(value, Sequence):
+    raise ValueError(f'{column} must contain a sequence.')
+  return tuple(value)
+
+
+def _float_token(value: Any, column: str) -> str:
+  try:
+    number = float(value)
+  except (TypeError, ValueError) as error:
+    raise ValueError(f'{column} must contain numeric returns.') from error
+  if math.isnan(number):
+    return 'nan'
+  if math.isinf(number):
+    return '+inf' if number > 0 else '-inf'
+  return number.hex()
+
+
+def _merkle_root(episode_digests: Sequence[str]) -> str:
+  if not episode_digests:
+    return hashlib.sha256(b'\x02').hexdigest()
+
+  level = [bytes.fromhex(digest) for digest in episode_digests]
+  while len(level) > 1:
+    if len(level) % 2:
+      level.append(level[-1])
+    level = [
+        hashlib.sha256(b'\x01' + level[index] + level[index + 1]).digest()
+        for index in range(0, len(level), 2)
+    ]
+  return level[0].hex()
+
+
+def _configuration_payload(target: str) -> dict[str, Any]:
+  if target in scenario_configs.SCENARIO_CONFIGS:
+    scenario = scenario_configs.SCENARIO_CONFIGS[target]
+    background_bots = (
+        set().union(*scenario.bots_by_role.values())
+        if scenario.bots_by_role
+        else set()
+    )
+    return {
+        'kind': 'scenario',
+        'name': target,
+        'scenario': {
+            'substrate': scenario.substrate,
+            'roles': list(scenario.roles),
+            'is_focal': list(scenario.is_focal),
+            'bots_by_role': {
+                role: sorted(scenario.bots_by_role[role])
+                for role in sorted(scenario.bots_by_role)
+            },
+        },
+        'background_bots': {
+            name: _bot_signature(name) for name in sorted(background_bots)
+        },
+        'substrate': _substrate_signature(
+            scenario.substrate, include_default_roles=False
+        ),
+    }
+
+  if target in substrate_configs.SUBSTRATES:
+    return {
+        'kind': 'substrate',
+        'name': target,
+        'substrate': _substrate_signature(target, include_default_roles=True),
+    }
+
+  raise ValueError(f'Unknown substrate or scenario: {target!r}.')
+
+
+def _bot_signature(name: str) -> dict[str, Any]:
+  if name == bot_lib.NOOP_BOT_NAME:
+    return {
+        'name': name,
+        'kind': 'fixed_action',
+        'action': bot_lib.NOOP_ACTION,
+    }
+  config = bot_configs.BOT_CONFIGS[name]
+  model_name = pathlib.Path(config.model_path).name
+  return {
+      'name': name,
+      'kind': 'configured_bot',
+      'substrate': config.substrate,
+      'roles': sorted(config.roles),
+      'model': model_name,
+      'puppeteer_builder': _normalize_value(config.puppeteer_builder),
+  }
+
+
+def _substrate_signature(
+    name: str, *, include_default_roles: bool
+) -> dict[str, Any]:
+  config = substrate_configs.get_config(name)
+  timestep_spec = config.timestep_spec
+  signature = {
+      'name': name,
+      'valid_roles': sorted(config.valid_roles),
+      'individual_observation_names': list(config.individual_observation_names),
+      'global_observation_names': list(config.global_observation_names),
+      'action_set': _normalize_value(config.action_set),
+      'action_spec': _spec_payload(config.action_spec),
+      'timestep_spec': {
+          'step_type': _spec_payload(timestep_spec.step_type),
+          'reward': _spec_payload(timestep_spec.reward),
+          'discount': _spec_payload(timestep_spec.discount),
+          'observation': {
+              key: _spec_payload(timestep_spec.observation[key])
+              for key in sorted(timestep_spec.observation)
+          },
+      },
+  }
+  if include_default_roles:
+    signature['default_player_roles'] = list(config.default_player_roles)
+  return signature
+
+
+def _spec_payload(spec: Any) -> dict[str, Any]:
+  payload = {
+      'type': type(spec).__name__,
+      'shape': list(spec.shape),
+      'dtype': np.dtype(spec.dtype).name,
+      'name': spec.name,
+  }
+  if hasattr(spec, 'num_values'):
+    payload['num_values'] = int(spec.num_values)
+  if hasattr(spec, 'minimum'):
+    payload['minimum'] = _normalize_value(spec.minimum)
+  if hasattr(spec, 'maximum'):
+    payload['maximum'] = _normalize_value(spec.maximum)
+  return payload
+
+
+def _normalize_value(value: Any) -> Any:
+  if value is None or isinstance(value, (bool, int, str)):
+    return value
+  if isinstance(value, (float, np.floating)):
+    return {'__float__': _float_token(value, 'configuration')}
+  if isinstance(value, np.integer):
+    return int(value)
+  if isinstance(value, np.ndarray):
+    return {
+        '__ndarray__': {
+            'dtype': np.dtype(value.dtype).name,
+            'shape': list(value.shape),
+            'values': _normalize_value(value.tolist()),
+        }
+    }
+  if dataclasses.is_dataclass(value) and not isinstance(value, type):
+    return {
+        '__dataclass__': (
+            f'{type(value).__module__}.{type(value).__qualname__}'
+        ),
+        'fields': {
+            field.name: _normalize_value(getattr(value, field.name))
+            for field in dataclasses.fields(value)
+        },
+    }
+  if isinstance(value, functools.partial):
+    return {
+        '__partial__': _normalize_value(value.func),
+        'args': _normalize_value(value.args),
+        'keywords': _normalize_value(value.keywords or {}),
+    }
+  if callable(value):
+    qualname = getattr(value, '__qualname__', value.__name__)
+    return {'__callable__': f'{value.__module__}.{qualname}'}
+  if isinstance(value, Mapping):
+    return {
+        str(key): _normalize_value(value[key])
+        for key in sorted(value, key=str)
+    }
+  if isinstance(value, (set, frozenset)):
+    normalized = [_normalize_value(item) for item in value]
+    return sorted(normalized, key=lambda item: _canonical_json(item))
+  if isinstance(value, Sequence) and not isinstance(value, (str, bytes)):
+    return [_normalize_value(item) for item in value]
+  raise TypeError(
+      f'Unsupported configuration value {type(value).__name__}: {value!r}.'
+  )
+
+
+def _target_kind(target: str) -> str:
+  if target in scenario_configs.SCENARIO_CONFIGS:
+    return 'scenario'
+  if target in substrate_configs.SUBSTRATES:
+    return 'substrate'
+  raise ValueError(f'Unknown substrate or scenario: {target!r}.')
+
+
+def _runtime_versions() -> tuple[tuple[str, str], ...]:
+  versions = {'python': platform.python_version()}
+  for distribution in _RUNTIME_DISTRIBUTIONS:
+    try:
+      version = importlib.metadata.version(distribution)
+    except importlib.metadata.PackageNotFoundError:
+      version = '<unknown>'
+    versions[distribution] = version
+  return tuple(sorted(versions.items()))
+
+
+def _validate_result_columns(results: pd.DataFrame) -> None:
+  missing = _REQUIRED_RESULT_COLUMNS - set(results.columns)
+  if missing and len(results):
+    raise ValueError(
+        f'Evaluation results are missing columns: {sorted(missing)!r}.'
+    )
+
+
+def _validate_digest(value: str, field: str) -> None:
+  if len(value) != hashlib.sha256().digest_size * 2:
+    raise ValueError(f'{field} is not a SHA-256 digest.')
+  try:
+    bytes.fromhex(value)
+  except ValueError as error:
+    raise ValueError(f'{field} is not a SHA-256 digest.') from error
+
+
+def _canonical_json(value: Any) -> bytes:
+  return json.dumps(
+      value,
+      sort_keys=True,
+      separators=(',', ':'),
+      ensure_ascii=False,
+      allow_nan=False,
+  ).encode('utf-8')
+
+
+def evaluate_population_with_manifest(
+    population: Mapping[str, Any],
+    names_by_role: Mapping[str, Collection[str]],
+    target: str,
+    num_episodes: int = 100,
+    video_root: str | None = None,
+) -> tuple[pd.DataFrame, EvaluationManifest]:
+  """Evaluates a population and returns results with their manifest.
+
+  This is a convenience wrapper around ``evaluation.evaluate_population`` that
+  leaves the existing evaluation API unchanged while ensuring the returned table
+  is immediately fingerprinted.
+
+  Args:
+    population: population mapping accepted by ``evaluate_population``.
+    names_by_role: policy names that support each role.
+    target: scenario or substrate to evaluate.
+    num_episodes: number of episodes to run.
+    video_root: optional directory for episode videos.
+
+  Returns:
+    ``(results, manifest)`` for the completed evaluation.
+  """
+  # Imported lazily to avoid a module cycle: evaluation imports sibling helpers.
+  # pylint: disable=g-import-not-at-top
+  from meltingpot.utils.evaluation import evaluation as evaluation_lib
+  # pylint: enable=g-import-not-at-top
+
+  results = evaluation_lib.evaluate_population(
+      population=population,
+      names_by_role=names_by_role,
+      scenario=target,
+      num_episodes=num_episodes,
+      video_root=video_root,
+  )
+  return results, create_manifest(results, target)
+
+
+def evaluate_saved_models_with_manifest(
+    saved_models: Mapping[str, str],
+    names_by_role: Mapping[str, Collection[str]],
+    target: str,
+    num_episodes: int = 100,
+    video_root: str | None = None,
+) -> tuple[pd.DataFrame, EvaluationManifest]:
+  """Evaluates saved models and returns results with their manifest.
+
+  Args:
+    saved_models: saved model names and paths accepted by
+      ``evaluation.evaluate_saved_models``.
+    names_by_role: policy names that support each role.
+    target: scenario or substrate to evaluate.
+    num_episodes: number of episodes to run.
+    video_root: optional directory for episode videos.
+
+  Returns:
+    ``(results, manifest)`` for the completed evaluation.
+  """
+  # pylint: disable=g-import-not-at-top
+  from meltingpot.utils.evaluation import evaluation as evaluation_lib
+  # pylint: enable=g-import-not-at-top
+
+  results = evaluation_lib.evaluate_saved_models(
+      saved_models=saved_models,
+      names_by_role=names_by_role,
+      scenario=target,
+      num_episodes=num_episodes,
+      video_root=video_root,
+  )
+  return results, create_manifest(results, target)

--- a/meltingpot/utils/evaluation/evaluation_manifest_integration_test.py
+++ b/meltingpot/utils/evaluation/evaluation_manifest_integration_test.py
@@ -1,0 +1,100 @@
+# Copyright 2026 DeepMind Technologies Limited.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Tests for manifest-producing evaluation convenience functions."""
+
+from unittest import mock
+
+from absl.testing import absltest
+from meltingpot.utils.evaluation import evaluation
+from meltingpot.utils.evaluation import evaluation_manifest
+import pandas as pd
+
+
+_RESULTS = pd.DataFrame({
+    'background_player_names': [('background',)],
+    'background_player_returns': [(1.0,)],
+    'focal_player_names': [('focal',)],
+    'focal_player_returns': [(2.0,)],
+})
+
+
+class EvaluationWithManifestTest(absltest.TestCase):
+
+  def test_population_wrapper_delegates_and_fingerprints_result(self):
+    manifest = mock.sentinel.manifest
+    population = {'focal': mock.sentinel.policy}
+    names_by_role = {'default': {'focal'}}
+
+    with mock.patch.object(
+        evaluation, 'evaluate_population', return_value=_RESULTS
+    ) as evaluate_population:
+      with mock.patch.object(
+          evaluation_manifest, 'create_manifest', return_value=manifest
+      ) as create_manifest:
+        actual_results, actual_manifest = (
+            evaluation_manifest.evaluate_population_with_manifest(
+                population=population,
+                names_by_role=names_by_role,
+                target='clean_up',
+                num_episodes=7,
+                video_root='/tmp/videos',
+            )
+        )
+
+    self.assertIs(actual_results, _RESULTS)
+    self.assertIs(actual_manifest, manifest)
+    evaluate_population.assert_called_once_with(
+        population=population,
+        names_by_role=names_by_role,
+        scenario='clean_up',
+        num_episodes=7,
+        video_root='/tmp/videos',
+    )
+    create_manifest.assert_called_once_with(_RESULTS, 'clean_up')
+
+  def test_saved_model_wrapper_delegates_and_fingerprints_result(self):
+    manifest = mock.sentinel.manifest
+    saved_models = {'focal': '/models/focal'}
+    names_by_role = {'default': {'focal'}}
+
+    with mock.patch.object(
+        evaluation, 'evaluate_saved_models', return_value=_RESULTS
+    ) as evaluate_saved_models:
+      with mock.patch.object(
+          evaluation_manifest, 'create_manifest', return_value=manifest
+      ) as create_manifest:
+        actual_results, actual_manifest = (
+            evaluation_manifest.evaluate_saved_models_with_manifest(
+                saved_models=saved_models,
+                names_by_role=names_by_role,
+                target='clean_up_20',
+                num_episodes=9,
+                video_root=None,
+            )
+        )
+
+    self.assertIs(actual_results, _RESULTS)
+    self.assertIs(actual_manifest, manifest)
+    evaluate_saved_models.assert_called_once_with(
+        saved_models=saved_models,
+        names_by_role=names_by_role,
+        scenario='clean_up_20',
+        num_episodes=9,
+        video_root=None,
+    )
+    create_manifest.assert_called_once_with(_RESULTS, 'clean_up_20')
+
+
+if __name__ == '__main__':
+  absltest.main()

--- a/meltingpot/utils/evaluation/evaluation_manifest_noop_test.py
+++ b/meltingpot/utils/evaluation/evaluation_manifest_noop_test.py
@@ -1,0 +1,41 @@
+# Copyright 2026 DeepMind Technologies Limited.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Coverage for manifesting scenarios that use the built-in noop bot."""
+
+from absl.testing import absltest
+from meltingpot import bot
+from meltingpot.utils.evaluation import evaluation_manifest
+
+
+class NoopBotManifestTest(absltest.TestCase):
+
+  def test_noop_bot_has_explicit_signature(self):
+    self.assertEqual(
+        evaluation_manifest._bot_signature(bot.NOOP_BOT_NAME),
+        {
+            'name': 'noop_bot',
+            'kind': 'fixed_action',
+            'action': bot.NOOP_ACTION,
+        },
+    )
+
+  def test_noop_scenario_can_be_fingerprinted(self):
+    digest = evaluation_manifest.configuration_hash(
+        'collaborative_cooking__asymmetric_0'
+    )
+    self.assertLen(digest, 64)
+
+
+if __name__ == '__main__':
+  absltest.main()

--- a/meltingpot/utils/evaluation/evaluation_manifest_test.py
+++ b/meltingpot/utils/evaluation/evaluation_manifest_test.py
@@ -1,0 +1,407 @@
+# Copyright 2026 DeepMind Technologies Limited.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Tests for evaluation result manifests."""
+
+import dataclasses
+from unittest import mock
+
+from absl.testing import absltest
+from meltingpot.configs import bots as bot_configs
+from meltingpot.configs import scenarios as scenario_configs
+from meltingpot.utils.evaluation import evaluation_manifest
+import numpy as np
+import pandas as pd
+
+
+def _results() -> pd.DataFrame:
+  return pd.DataFrame({
+      'background_player_names': [
+          ('background_a',),
+          ('background_b',),
+          ('background_c',),
+      ],
+      'background_player_returns': [
+          (1.0,),
+          (2.5,),
+          (-4.0,),
+      ],
+      'focal_player_names': [
+          ('focal_a', 'focal_b'),
+          ('focal_a', 'focal_b'),
+          ('focal_a', 'focal_b'),
+      ],
+      'focal_player_returns': [
+          (3.0, -0.0),
+          (np.nan, np.inf),
+          (-np.inf, 7.25),
+      ],
+      'focal_per_capita_return': [1.5, np.nan, -np.inf],
+      'background_per_capita_return': [1.0, 2.5, -4.0],
+      'video_path': [
+          '/tmp/run/episode_0.mp4',
+          '/tmp/run/episode_1.mp4',
+          '/tmp/run/episode_2.mp4',
+      ],
+  })
+
+
+class ContentHashTest(absltest.TestCase):
+
+  def test_is_deterministic(self):
+    results = _results()
+    self.assertEqual(
+        evaluation_manifest.content_hash(results),
+        evaluation_manifest.content_hash(results.copy(deep=True)),
+    )
+
+  def test_ignores_video_paths_and_derived_per_capita_columns(self):
+    left = _results()
+    right = _results()
+    right['video_path'] = ['/other/a', '/other/b', '/other/c']
+    right['focal_per_capita_return'] = [999.0, 999.0, 999.0]
+    right['background_per_capita_return'] = [-999.0, -999.0, -999.0]
+
+    self.assertEqual(
+        evaluation_manifest.content_hash(left),
+        evaluation_manifest.content_hash(right),
+    )
+
+  def test_changed_return_changes_only_its_episode_leaf(self):
+    original = _results()
+    changed = _results()
+    changed.at[1, 'focal_player_returns'] = (10.0, 11.0)
+
+    original_leaves = evaluation_manifest.episode_hashes(original)
+    changed_leaves = evaluation_manifest.episode_hashes(changed)
+
+    self.assertEqual(original_leaves[0], changed_leaves[0])
+    self.assertNotEqual(original_leaves[1], changed_leaves[1])
+    self.assertEqual(original_leaves[2], changed_leaves[2])
+    self.assertNotEqual(
+        evaluation_manifest.content_hash(original),
+        evaluation_manifest.content_hash(changed),
+    )
+
+  def test_changed_player_name_changes_content(self):
+    original = _results()
+    changed = _results()
+    changed.at[0, 'focal_player_names'] = ('different', 'focal_b')
+
+    self.assertNotEqual(
+        evaluation_manifest.content_hash(original),
+        evaluation_manifest.content_hash(changed),
+    )
+
+  def test_episode_order_is_part_of_content(self):
+    original = _results()
+    reversed_results = original.iloc[::-1].reset_index(drop=True)
+
+    self.assertNotEqual(
+        evaluation_manifest.content_hash(original),
+        evaluation_manifest.content_hash(reversed_results),
+    )
+
+  def test_dataframe_index_is_not_part_of_content(self):
+    original = _results()
+    reindexed = original.copy()
+    reindexed.index = [100, 200, 300]
+
+    self.assertEqual(
+        evaluation_manifest.content_hash(original),
+        evaluation_manifest.content_hash(reindexed),
+    )
+
+  def test_exact_float_representation_distinguishes_signed_zero(self):
+    positive = _results().iloc[[0]].copy()
+    negative = _results().iloc[[0]].copy()
+    positive.at[positive.index[0], 'focal_player_returns'] = (3.0, 0.0)
+
+    self.assertNotEqual(
+        evaluation_manifest.content_hash(positive),
+        evaluation_manifest.content_hash(negative),
+    )
+
+  def test_empty_results_have_deterministic_root(self):
+    empty = pd.DataFrame()
+    self.assertEqual(
+        evaluation_manifest.content_hash(empty),
+        evaluation_manifest.content_hash(empty.copy()),
+    )
+    self.assertEmpty(evaluation_manifest.episode_hashes(empty))
+
+  def test_missing_columns_are_rejected_for_nonempty_results(self):
+    with self.assertRaisesRegex(ValueError, 'missing columns'):
+      evaluation_manifest.content_hash(pd.DataFrame({'x': [1]}))
+
+  def test_name_return_lengths_must_match(self):
+    results = _results().iloc[[0]].copy()
+    results.at[results.index[0], 'focal_player_returns'] = (1.0,)
+
+    with self.assertRaisesRegex(ValueError, 'must have equal length'):
+      evaluation_manifest.content_hash(results)
+
+  def test_returns_must_be_numeric(self):
+    results = _results().iloc[[0]].copy()
+    results.at[results.index[0], 'focal_player_returns'] = ('bad', 1.0)
+
+    with self.assertRaisesRegex(ValueError, 'numeric returns'):
+      evaluation_manifest.content_hash(results)
+
+
+class ConfigurationHashTest(absltest.TestCase):
+
+  def test_substrate_configuration_hash_is_deterministic(self):
+    first = evaluation_manifest.configuration_hash('clean_up')
+    second = evaluation_manifest.configuration_hash('clean_up')
+    self.assertEqual(first, second)
+    self.assertLen(first, 64)
+
+  def test_scenario_configuration_hash_is_deterministic(self):
+    first = evaluation_manifest.configuration_hash('clean_up_20')
+    second = evaluation_manifest.configuration_hash('clean_up_20')
+    self.assertEqual(first, second)
+    self.assertLen(first, 64)
+
+  def test_scenario_bot_pool_changes_configuration_hash(self):
+    base = scenario_configs.ScenarioConfig(
+        description='same description',
+        tags={'same_tag'},
+        substrate='clean_up',
+        roles=('default', 'default'),
+        is_focal=(True, False),
+        bots_by_role={'default': {'bot_a'}},
+    )
+    changed = scenario_configs.ScenarioConfig(
+        description='same description',
+        tags={'same_tag'},
+        substrate='clean_up',
+        roles=('default', 'default'),
+        is_focal=(True, False),
+        bots_by_role={'default': {'bot_b'}},
+    )
+
+    with mock.patch.object(
+        evaluation_manifest,
+        '_substrate_signature',
+        return_value={'fixed': True},
+    ):
+      with mock.patch.object(
+          evaluation_manifest.scenario_configs,
+          'SCENARIO_CONFIGS',
+          {'example': base},
+      ):
+        first = evaluation_manifest.configuration_hash('example')
+      with mock.patch.object(
+          evaluation_manifest.scenario_configs,
+          'SCENARIO_CONFIGS',
+          {'example': changed},
+      ):
+        second = evaluation_manifest.configuration_hash('example')
+
+    self.assertNotEqual(first, second)
+
+  def test_background_bot_config_changes_configuration_hash(self):
+    scenario = scenario_configs.ScenarioConfig(
+        description='same',
+        tags={'same'},
+        substrate='clean_up',
+        roles=('default', 'default'),
+        is_focal=(True, False),
+        bots_by_role={'default': {'bot_a'}},
+    )
+    base_bot = bot_configs.BotConfig(
+        substrate='clean_up',
+        roles={'default'},
+        model_path='/models/clean_up/model_a',
+        puppeteer_builder=None,
+    )
+    changed_bot = bot_configs.BotConfig(
+        substrate='clean_up',
+        roles={'default'},
+        model_path='/models/clean_up/model_b',
+        puppeteer_builder=None,
+    )
+
+    with mock.patch.object(
+        evaluation_manifest,
+        '_substrate_signature',
+        return_value={'fixed': True},
+    ):
+      with mock.patch.object(
+          evaluation_manifest.scenario_configs,
+          'SCENARIO_CONFIGS',
+          {'example': scenario},
+      ):
+        with mock.patch.object(
+            evaluation_manifest.bot_configs,
+            'BOT_CONFIGS',
+            {'bot_a': base_bot},
+        ):
+          first = evaluation_manifest.configuration_hash('example')
+        with mock.patch.object(
+            evaluation_manifest.bot_configs,
+            'BOT_CONFIGS',
+            {'bot_a': changed_bot},
+        ):
+          second = evaluation_manifest.configuration_hash('example')
+
+    self.assertNotEqual(first, second)
+
+  def test_descriptive_metadata_does_not_change_configuration_hash(self):
+    base = scenario_configs.ScenarioConfig(
+        description='description one',
+        tags={'tag_one'},
+        substrate='clean_up',
+        roles=('default', 'default'),
+        is_focal=(True, False),
+        bots_by_role={'default': {'bot_a'}},
+    )
+    changed = scenario_configs.ScenarioConfig(
+        description='description two',
+        tags={'tag_two'},
+        substrate='clean_up',
+        roles=('default', 'default'),
+        is_focal=(True, False),
+        bots_by_role={'default': {'bot_a'}},
+    )
+
+    with mock.patch.object(
+        evaluation_manifest,
+        '_substrate_signature',
+        return_value={'fixed': True},
+    ):
+      with mock.patch.object(
+          evaluation_manifest.scenario_configs,
+          'SCENARIO_CONFIGS',
+          {'example': base},
+      ):
+        first = evaluation_manifest.configuration_hash('example')
+      with mock.patch.object(
+          evaluation_manifest.scenario_configs,
+          'SCENARIO_CONFIGS',
+          {'example': changed},
+      ):
+        second = evaluation_manifest.configuration_hash('example')
+
+    self.assertEqual(first, second)
+
+  def test_unknown_target_is_rejected(self):
+    with self.assertRaisesRegex(ValueError, 'Unknown substrate or scenario'):
+      evaluation_manifest.configuration_hash('does_not_exist')
+
+
+class ManifestTest(absltest.TestCase):
+
+  def setUp(self):
+    super().setUp()
+    self.results = _results()
+    self.manifest = evaluation_manifest.create_manifest(
+        self.results, 'clean_up_20'
+    )
+
+  def test_contains_episode_and_configuration_fingerprints(self):
+    self.assertEqual(self.manifest.schema_version, 1)
+    self.assertEqual(self.manifest.hash_algorithm, 'sha256')
+    self.assertEqual(self.manifest.target, 'clean_up_20')
+    self.assertEqual(self.manifest.target_kind, 'scenario')
+    self.assertEqual(self.manifest.num_episodes, 3)
+    self.assertLen(self.manifest.configuration_sha256, 64)
+    self.assertLen(self.manifest.content_sha256, 64)
+    self.assertLen(self.manifest.episode_sha256, 3)
+    self.assertIn(('python', mock.ANY), self.manifest.runtime_versions)
+
+  def test_json_round_trip(self):
+    decoded = evaluation_manifest.EvaluationManifest.from_json(
+        self.manifest.to_json()
+    )
+    self.assertEqual(decoded, self.manifest)
+
+  def test_file_round_trip(self):
+    path = self.create_tempfile().full_path
+    self.manifest.write(path)
+    decoded = evaluation_manifest.EvaluationManifest.read(path)
+    self.assertEqual(decoded, self.manifest)
+
+  def test_verify_accepts_matching_results(self):
+    evaluation_manifest.verify_manifest(self.manifest, self.results)
+
+  def test_verify_reports_first_changed_episode(self):
+    changed = _results()
+    changed.at[1, 'background_player_returns'] = (123.0,)
+
+    with self.assertRaisesRegex(
+        evaluation_manifest.EvaluationManifestMismatch,
+        r'Episode 1 content hash mismatch',
+    ):
+      evaluation_manifest.verify_manifest(self.manifest, changed)
+
+  def test_verify_reports_episode_count_change(self):
+    changed = self.results.iloc[:2]
+    with self.assertRaisesRegex(
+        evaluation_manifest.EvaluationManifestMismatch,
+        'Episode count mismatch',
+    ):
+      evaluation_manifest.verify_manifest(self.manifest, changed)
+
+  def test_configuration_check_can_be_disabled(self):
+    changed_manifest = dataclasses.replace(
+        self.manifest, configuration_sha256='0' * 64
+    )
+
+    with self.assertRaisesRegex(
+        evaluation_manifest.EvaluationManifestMismatch,
+        'Configuration hash mismatch',
+    ):
+      evaluation_manifest.verify_manifest(changed_manifest, self.results)
+
+    evaluation_manifest.verify_manifest(
+        changed_manifest, self.results, check_configuration=False
+    )
+
+  def test_runtime_check_is_opt_in(self):
+    changed_manifest = dataclasses.replace(
+        self.manifest, runtime_versions=(('python', '0.0.0'),)
+    )
+
+    evaluation_manifest.verify_manifest(changed_manifest, self.results)
+
+    with self.assertRaisesRegex(
+        evaluation_manifest.EvaluationManifestMismatch,
+        'Runtime versions',
+    ):
+      evaluation_manifest.verify_manifest(
+          changed_manifest, self.results, check_runtime=True
+      )
+
+  def test_from_dict_rejects_invalid_digest(self):
+    value = self.manifest.to_dict()
+    value['content_sha256'] = 'not-a-digest'
+    with self.assertRaisesRegex(ValueError, 'SHA-256'):
+      evaluation_manifest.EvaluationManifest.from_dict(value)
+
+  def test_from_dict_rejects_unknown_schema(self):
+    value = self.manifest.to_dict()
+    value['schema_version'] = 999
+    with self.assertRaisesRegex(ValueError, 'Unsupported evaluation manifest'):
+      evaluation_manifest.EvaluationManifest.from_dict(value)
+
+  def test_from_dict_rejects_wrong_episode_digest_count(self):
+    value = self.manifest.to_dict()
+    value['episode_sha256'] = value['episode_sha256'][:-1]
+    with self.assertRaisesRegex(ValueError, 'does not match num_episodes'):
+      evaluation_manifest.EvaluationManifest.from_dict(value)
+
+
+if __name__ == '__main__':
+  absltest.main()

--- a/meltingpot/utils/evaluation/evaluation_manifest_test.py
+++ b/meltingpot/utils/evaluation/evaluation_manifest_test.py
@@ -14,6 +14,7 @@
 """Tests for evaluation result manifests."""
 
 import dataclasses
+import tempfile
 from unittest import mock
 
 from absl.testing import absltest
@@ -197,17 +198,22 @@ class ConfigurationHashTest(absltest.TestCase):
         return_value={'fixed': True},
     ):
       with mock.patch.object(
-          evaluation_manifest.scenario_configs,
-          'SCENARIO_CONFIGS',
-          {'example': base},
+          evaluation_manifest,
+          '_bot_signature',
+          side_effect=lambda name: {'name': name},
       ):
-        first = evaluation_manifest.configuration_hash('example')
-      with mock.patch.object(
-          evaluation_manifest.scenario_configs,
-          'SCENARIO_CONFIGS',
-          {'example': changed},
-      ):
-        second = evaluation_manifest.configuration_hash('example')
+        with mock.patch.object(
+            evaluation_manifest.scenario_configs,
+            'SCENARIO_CONFIGS',
+            {'example': base},
+        ):
+          first = evaluation_manifest.configuration_hash('example')
+        with mock.patch.object(
+            evaluation_manifest.scenario_configs,
+            'SCENARIO_CONFIGS',
+            {'example': changed},
+        ):
+          second = evaluation_manifest.configuration_hash('example')
 
     self.assertNotEqual(first, second)
 
@@ -282,17 +288,22 @@ class ConfigurationHashTest(absltest.TestCase):
         return_value={'fixed': True},
     ):
       with mock.patch.object(
-          evaluation_manifest.scenario_configs,
-          'SCENARIO_CONFIGS',
-          {'example': base},
+          evaluation_manifest,
+          '_bot_signature',
+          side_effect=lambda name: {'name': name},
       ):
-        first = evaluation_manifest.configuration_hash('example')
-      with mock.patch.object(
-          evaluation_manifest.scenario_configs,
-          'SCENARIO_CONFIGS',
-          {'example': changed},
-      ):
-        second = evaluation_manifest.configuration_hash('example')
+        with mock.patch.object(
+            evaluation_manifest.scenario_configs,
+            'SCENARIO_CONFIGS',
+            {'example': base},
+        ):
+          first = evaluation_manifest.configuration_hash('example')
+        with mock.patch.object(
+            evaluation_manifest.scenario_configs,
+            'SCENARIO_CONFIGS',
+            {'example': changed},
+        ):
+          second = evaluation_manifest.configuration_hash('example')
 
     self.assertEqual(first, second)
 
@@ -328,9 +339,10 @@ class ManifestTest(absltest.TestCase):
     self.assertEqual(decoded, self.manifest)
 
   def test_file_round_trip(self):
-    path = self.create_tempfile().full_path
-    self.manifest.write(path)
-    decoded = evaluation_manifest.EvaluationManifest.read(path)
+    with tempfile.TemporaryDirectory() as temp_dir:
+      path = f'{temp_dir}/manifest.json'
+      self.manifest.write(path)
+      decoded = evaluation_manifest.EvaluationManifest.read(path)
     self.assertEqual(decoded, self.manifest)
 
   def test_verify_accepts_matching_results(self):


### PR DESCRIPTION
## Summary

Add versioned reproducibility manifests for episode-level Melting Pot evaluations.

This addresses the evaluation integrity and scenario-version-drift concern raised in #338 without changing any existing evaluation API or return type.

Aggregate scores do not identify the exact episode outcomes or evaluation definition that produced them. This change adds a manifest format with two independent fingerprints:

- a content fingerprint over the exact episode-level results
- a configuration fingerprint over the scenario/substrate and background-policy definition

### Episode content fingerprint

Each episode is canonicalized as ordered focal and background player records binding policy/bot names to exact returns. Finite floating-point values use their exact hexadecimal representation, with explicit tokens for NaN and infinities.

Each episode gets a domain-separated SHA-256 leaf hash. The manifest stores those leaves and a domain-separated Merkle root over the full evaluation, so result changes can be detected and localized to the first differing episode.

Machine-specific or derived fields such as `video_path`, the DataFrame index, and per-capita return columns are intentionally excluded.

### Configuration fingerprint

The separate configuration digest commits to evaluation-relevant target configuration.

For scenarios this includes:
- the underlying substrate
- player roles in slot order
- focal/background assignment in slot order
- background bot pools by role
- each referenced background bot's model identity, supported roles, and puppeteer constructor configuration
- the substrate's public actions, timestep/observation specs, and supported roles

The built-in `noop_bot` is represented explicitly as a fixed-action policy, so scenarios without a saved-model-backed background bot are supported as well.

For direct substrate evaluation, the default player-role assignment is also included because that assignment is used by the evaluation helper.

Descriptive scenario text and tags are excluded because they do not change evaluation semantics.

### Manifest API

The new `EvaluationManifest` supports deterministic JSON serialization and file round trips.

Public helpers include:
- `create_manifest`
- `verify_manifest`
- `episode_hashes`
- `content_hash`
- `configuration_hash`
- `evaluate_population_with_manifest`
- `evaluate_saved_models_with_manifest`

`verify_manifest` checks result content and current target configuration by default. Runtime package versions are recorded for diagnostics and can optionally be enforced with `check_runtime=True`.

### Runtime metadata

The manifest records Python plus installed versions of `dm-meltingpot`, `dmlab2d`, `dm-env`, `numpy`, `pandas`, and `tensorflow`.

### Documentation

Adds a guide describing the canonicalization boundary, Merkle construction, configuration fingerprint, verification workflow, runtime metadata, and limitations. The manifest is an integrity/reproducibility record rather than an authenticity signature.

## Testing

Added focused coverage for:
- deterministic hashing
- exact floating-point canonicalization, including signed zero, NaN, and infinities
- episode order and DataFrame-index behavior
- exclusion of video paths and derived per-capita columns
- per-episode mismatch localization
- malformed result and manifest validation
- JSON/file serialization round trips
- scenario bot-pool drift
- background bot model/config drift
- direct substrate and scenario configuration hashes
- built-in `noop_bot` scenarios
- optional configuration and runtime verification
- manifest-producing evaluation wrapper delegation

The branch is based on the current upstream `main`. I could not run the full Melting Pot test suite in this environment because the local runtime does not contain the project dependencies; the tests are included for upstream CI.
