### PR TITLE
Validate population role candidates at construction

### DIFF
--- a/meltingpot/utils/scenarios/population.py
+++ b/meltingpot/utils/scenarios/population.py
@@ -84,6 +84,18 @@ class Population:
         role: tuple(set(names)) for role, names in names_by_role.items()}
     self._roles = tuple(roles)
 
+    for role in set(self._roles):
+      if role not in self._names_by_role:
+        raise ValueError(f'No population candidates configured for role {role!r}.')
+      candidates = self._names_by_role[role]
+      if not candidates:
+        raise ValueError(f'Population candidates for role {role!r} are empty.')
+      unknown_names = set(candidates) - self._policies.keys()
+      if unknown_names:
+        raise ValueError(
+            f'Population candidates for role {role!r} reference unknown '
+            f'policies: {unknown_names!r}.')
+
     self._locks = {name: threading.Lock() for name in self._policies}
     self._executor = concurrent.futures.ThreadPoolExecutor(
         max_workers=len(roles))

--- a/meltingpot/utils/scenarios/population_validation_test.py
+++ b/meltingpot/utils/scenarios/population_validation_test.py
@@ -1,0 +1,55 @@
+# Copyright 2026 DeepMind Technologies Limited.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Tests for population configuration validation."""
+
+from unittest import mock
+
+from absl.testing import absltest
+from meltingpot.utils.policies import policy
+from meltingpot.utils.scenarios import population
+
+
+class PopulationValidationTest(absltest.TestCase):
+
+  def setUp(self):
+    super().setUp()
+    self.policy = mock.Mock(spec_set=policy.Policy)
+
+  def test_rejects_missing_role_candidates(self):
+    with self.assertRaisesRegex(ValueError, 'No population candidates'):
+      population.Population(
+          policies={'bot': self.policy},
+          names_by_role={},
+          roles=['resident'],
+      )
+
+  def test_rejects_empty_role_candidates(self):
+    with self.assertRaisesRegex(ValueError, 'candidates.*empty'):
+      population.Population(
+          policies={'bot': self.policy},
+          names_by_role={'resident': ()},
+          roles=['resident'],
+      )
+
+  def test_rejects_unknown_policy_candidate(self):
+    with self.assertRaisesRegex(ValueError, 'unknown policies'):
+      population.Population(
+          policies={'bot': self.policy},
+          names_by_role={'resident': ('missing_bot',)},
+          roles=['resident'],
+      )
+
+
+if __name__ == '__main__':
+  absltest.main()


### PR DESCRIPTION
## Summary

Validate the bot candidates for every role used by `Population` when the population is constructed.

Malformed population configuration currently fails later during `reset()`:
- a missing role mapping raises `KeyError`
- an empty candidate collection reaches `random.choice([])`
- a candidate name absent from `policies` raises `KeyError` while building the step function

This change:
- requires every active role to have a candidate mapping
- requires each active role to have at least one candidate
- requires every candidate to name an available policy
- raises a clear `ValueError` before the executor and episode state are created
- leaves valid population sampling unchanged

## Testing

Added focused regression tests for missing role candidates, empty candidate collections, and unknown policy names.