### PR TITLE
Validate SanctionerAlternator alternating interval

### DIFF
--- a/meltingpot/utils/puppeteers/clean_up.py
+++ b/meltingpot/utils/puppeteers/clean_up.py
@@ -304,7 +304,10 @@ class SanctionerAlternator(puppeteer.Puppeteer[SanctionerAlternatorState]):
     self._threshold = threshold
     self._recency_window = recency_window
 
-    self._alternating_steps = alternating_steps
+    if alternating_steps > 0:
+      self._alternating_steps = alternating_steps
+    else:
+      raise ValueError('alternating_steps must be positive')
     self._nice = nice
 
     self._steps_to_sanction_when_motivated = steps_to_sanction_when_motivated

--- a/meltingpot/utils/puppeteers/sanctioner_alternator_validation_test.py
+++ b/meltingpot/utils/puppeteers/sanctioner_alternator_validation_test.py
@@ -15,6 +15,7 @@
 
 from unittest import mock
 
+from absl.testing import absltest
 from absl.testing import parameterized
 from meltingpot.utils.puppeteers import clean_up
 
@@ -35,4 +36,4 @@ class SanctionerAlternatorValidationTest(parameterized.TestCase):
 
 
 if __name__ == '__main__':
-  parameterized.absltest.main()
+  absltest.main()

--- a/meltingpot/utils/puppeteers/sanctioner_alternator_validation_test.py
+++ b/meltingpot/utils/puppeteers/sanctioner_alternator_validation_test.py
@@ -1,0 +1,38 @@
+# Copyright 2026 DeepMind Technologies Limited.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Validation tests for SanctionerAlternator."""
+
+from unittest import mock
+
+from absl.testing import parameterized
+from meltingpot.utils.puppeteers import clean_up
+
+
+class SanctionerAlternatorValidationTest(parameterized.TestCase):
+
+  @parameterized.parameters(0, -1)
+  def test_rejects_nonpositive_alternating_steps(self, alternating_steps):
+    with self.assertRaisesRegex(ValueError, 'alternating_steps must be positive'):
+      clean_up.SanctionerAlternator(
+          cooperate_goal=mock.sentinel.cooperate,
+          defect_goal=mock.sentinel.defect,
+          sanction_goal=mock.sentinel.sanction,
+          num_others_cooperating_cumulant='NUM_OTHERS_COOPERATING',
+          threshold=1,
+          alternating_steps=alternating_steps,
+      )
+
+
+if __name__ == '__main__':
+  parameterized.absltest.main()


### PR DESCRIPTION
## Summary

Reject non-positive `alternating_steps` values when constructing `SanctionerAlternator`.

The interval is later used as the divisor in the cooperation/defection phase calculation. A value of zero is currently accepted by the constructor and then fails during `step()` with division by zero; negative intervals also do not define a meaningful alternation schedule.

This change:
- requires `alternating_steps` to be positive
- fails immediately with a clear `ValueError`
- leaves all valid alternation behavior unchanged
- adds focused regression coverage

## Testing

Added parameterized tests verifying that zero and negative alternating intervals are rejected at construction time.