### PR TITLE
Fix VideoSubject writer type narrowing

### DIFF
--- a/meltingpot/utils/evaluation/video_subject.py
+++ b/meltingpot/utils/evaluation/video_subject.py
@@ -83,18 +83,19 @@ class VideoSubject(subject.Subject):
           isColor=True)
     elif self._writer is None:
       raise ValueError('First timestep must be StepType.FIRST.')
-    assert self._writer is not None
+    writer = self._writer
+    assert writer is not None
 
-    if not self._writer.isOpened():
-      self._writer.release()
+    if not writer.isOpened():
+      writer.release()
       self._writer = None
       self._path = None
       raise RuntimeError('Failed to open video writer.')
 
     bgr_frame = cv2.cvtColor(rgb_frame, cv2.COLOR_RGB2BGR)
-    self._writer.write(bgr_frame)
+    writer.write(bgr_frame)
     if timestep.step_type.last():
-      self._writer.release()
+      writer.release()
       super().on_next(self._path)
       self._path = None
       self._writer = None


### PR DESCRIPTION
## Summary

Fix the current `pytype` failure in `VideoSubject.on_next` by keeping the validated `VideoWriter` reference in a local variable.

`self._writer` is optional and is reassigned to `None` later in the method. Pytype therefore does not retain the earlier non-`None` narrowing when `write()` and `release()` are called.

This change:
- captures the validated writer in a local `writer` variable
- uses that non-optional reference for `isOpened()`, `write()`, and `release()`
- leaves the existing `self._writer` lifecycle and runtime behavior unchanged

## Validation

- `python3 -m py_compile meltingpot/utils/evaluation/video_subject.py`
- `git diff --check`

This addresses the `Optional[Any]` attribute errors currently reported by `pytype meltingpot` on `write()` and `release()`.
